### PR TITLE
Implement invite-only registration flow

### DIFF
--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -146,6 +146,22 @@ const normalizeFileMeta = (raw) => {
   }
 }
 
+const normalizeInvite = (raw) => {
+  if (!raw) return null
+  return {
+    id: raw.id ?? '',
+    code: raw.code ?? '',
+    status: raw.status ?? 'active',
+    createdAt: raw.createdAt ?? raw.created_at ?? 0,
+    expiresAt: raw.expiresAt ?? raw.expires_at ?? 0,
+    claimedAt: raw.claimedAt ?? raw.claimed_at ?? 0,
+    usedAt: raw.usedAt ?? raw.used_at ?? 0,
+    usedBy: raw.usedBy ?? raw.used_by ?? '',
+    revokedAt: raw.revokedAt ?? raw.revoked_at ?? 0,
+    createdBy: raw.createdBy ?? raw.created_by ?? '',
+  }
+}
+
 const deriveKey = (cid) => {
   if (!cid) return null
   const source = encoder.encode(String(cid))
@@ -238,6 +254,7 @@ const useStore = create((set, get) => ({
   activeVoiceRoomId: null,
   voiceStatus: null,
   voiceStream: null,
+  invites: [],
 
   setAuth: (token, user) => set((state) => {
     const normalized = normalizeUser(user)
@@ -670,6 +687,43 @@ const useStore = create((set, get) => ({
       { currentPassword, newPassword },
       { headers: buildAuthHeaders(token) },
     )
+  },
+
+  fetchInvites: async () => {
+    const token = get().token
+    if (!token) return []
+    const { data } = await axios.get(`${get().serverUrl}/api/invites`, { headers: buildAuthHeaders(token) })
+    const invites = Array.isArray(data?.invites) ? data.invites.map(normalizeInvite).filter(Boolean) : []
+    set({ invites })
+    return invites
+  },
+
+  createInvite: async (ttlMs) => {
+    const token = get().token
+    if (!token) throw new Error('not_authenticated')
+    const payload = {}
+    if (ttlMs) payload.ttlMs = ttlMs
+    const { data } = await axios.post(`${get().serverUrl}/api/invites`, payload, { headers: buildAuthHeaders(token) })
+    const invite = normalizeInvite(data?.invite)
+    if (invite) {
+      set((state) => ({ invites: [invite, ...state.invites.filter((item) => item.id !== invite.id)] }))
+    }
+    return invite
+  },
+
+  revokeInvite: async (inviteId) => {
+    const token = get().token
+    if (!token) throw new Error('not_authenticated')
+    const { data } = await axios.post(
+      `${get().serverUrl}/api/invites/${inviteId}/revoke`,
+      {},
+      { headers: buildAuthHeaders(token) },
+    )
+    const invite = normalizeInvite(data?.invite)
+    if (invite) {
+      set((state) => ({ invites: state.invites.map((item) => (item.id === invite.id ? invite : item)) }))
+    }
+    return invite
   },
 
   // Admin helpers

--- a/client/src/ui/Login.jsx
+++ b/client/src/ui/Login.jsx
@@ -1,35 +1,358 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import axios from 'axios'
 import useStore from '../state/store.js'
+
+const formatDateTime = (timestamp) => {
+  if (!timestamp) return ''
+  try {
+    return new Date(timestamp).toLocaleString('ru-RU')
+  } catch (err) {
+    console.warn('date format failed', err)
+    return ''
+  }
+}
 
 export default function Login() {
   const [mode, setMode] = useState('login')
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [passwordConfirm, setPasswordConfirm] = useState('')
+  const [inviteCodeInput, setInviteCodeInput] = useState('')
+  const [inviteInfo, setInviteInfo] = useState(null)
   const [status, setStatus] = useState(null)
+  const [processing, setProcessing] = useState(false)
+  const [avatarFile, setAvatarFile] = useState(null)
+  const [avatarPreview, setAvatarPreview] = useState(null)
   const setAuth = useStore((s) => s.setAuth)
   const server = useStore((s) => s.serverUrl)
 
-  const submit = async (event) => {
+  useEffect(() => () => {
+    if (avatarPreview) URL.revokeObjectURL(avatarPreview)
+  }, [avatarPreview])
+
+  useEffect(() => {
+    setStatus(null)
+  }, [mode])
+
+  const resetAvatar = () => {
+    if (avatarPreview) URL.revokeObjectURL(avatarPreview)
+    setAvatarPreview(null)
+    setAvatarFile(null)
+  }
+
+  const resetForms = () => {
+    setUsername('')
+    setPassword('')
+    setPasswordConfirm('')
+    setInviteCodeInput('')
+    setInviteInfo(null)
+    resetAvatar()
+    setProcessing(false)
+    setStatus(null)
+  }
+
+  const goToLogin = () => {
+    resetForms()
+    setMode('login')
+  }
+
+  const handleLoginSubmit = async (event) => {
     event.preventDefault()
     setStatus(null)
+    setProcessing(true)
     try {
-      const url = mode === 'login' ? '/api/login' : '/api/register'
-      const { data } = await axios.post(server + url, { username, password })
+      const { data } = await axios.post(server + '/api/login', { username, password })
       setAuth(data.token, data.user)
     } catch (err) {
       console.error(err)
       const error = err?.response?.data?.error
       const message = (() => {
-        if (error === 'username_taken') return 'Такой логин уже используется'
-        if (err?.response?.status === 401) return 'Неверный логин или пароль'
-        return 'Не удалось выполнить запрос'
+        if (err?.response?.status === 401 || error === 'invalid_credentials') return 'Неверный логин или пароль'
+        return 'Не удалось выполнить вход'
       })()
       setStatus(message)
+    } finally {
+      setProcessing(false)
     }
   }
 
-  const isLogin = mode === 'login'
+  const handleInviteSubmit = async (event) => {
+    event.preventDefault()
+    const code = inviteCodeInput.trim()
+    if (!code) {
+      setStatus('Введите код приглашения')
+      return
+    }
+    setProcessing(true)
+    setStatus(null)
+    try {
+      const { data } = await axios.post(server + '/api/invites/claim', { code })
+      const info = {
+        code: data?.invite?.code || code.toUpperCase(),
+        claimToken: data?.claimToken || '',
+        expiresAt: data?.invite?.expiresAt || 0,
+        createdBy: data?.invite?.createdBy || null,
+      }
+      setInviteInfo(info)
+      setInviteCodeInput(info.code)
+      setMode('register')
+      setStatus('Код подтверждён. Заполните форму регистрации.')
+    } catch (err) {
+      console.error(err)
+      const error = err?.response?.data?.error
+      const message = (() => {
+        if (error === 'invalid_code') return 'Код не найден'
+        if (error === 'invite_expired') return 'Срок действия кода истёк'
+        if (error === 'invite_used') return 'Код уже использован'
+        if (error === 'invite_revoked') return 'Код был отозван'
+        return 'Не удалось проверить код'
+      })()
+      setStatus(message)
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const handleAvatarChange = (event) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+    if (!file.type?.startsWith('image/')) {
+      setStatus('Можно загрузить только изображение')
+      return
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setStatus('Аватар не должен превышать 5 МБ')
+      return
+    }
+    resetAvatar()
+    setAvatarFile(file)
+    setAvatarPreview(URL.createObjectURL(file))
+    setStatus(null)
+  }
+
+  const handleRegisterSubmit = async (event) => {
+    event.preventDefault()
+    if (!inviteInfo?.claimToken || !inviteInfo?.code) {
+      setStatus('Сначала подтвердите код приглашения')
+      return
+    }
+    const trimmedUsername = username.trim()
+    if (!trimmedUsername) {
+      setStatus('Введите имя пользователя')
+      return
+    }
+    if (!password || password.length < 8) {
+      setStatus('Пароль должен содержать минимум 8 символов, включая буквы и цифры')
+      return
+    }
+    if (!/[A-Za-z]/.test(password) || !/[0-9]/.test(password)) {
+      setStatus('Пароль должен содержать буквы и цифры')
+      return
+    }
+    if (password !== passwordConfirm) {
+      setStatus('Пароли не совпадают')
+      return
+    }
+    setProcessing(true)
+    setStatus(null)
+    try {
+      const payload = {
+        username: trimmedUsername,
+        password,
+        inviteCode: inviteInfo.code,
+        inviteClaimToken: inviteInfo.claimToken,
+      }
+      const { data } = await axios.post(server + '/api/register', payload)
+      setAuth(data.token, data.user)
+      if (avatarFile) {
+        try {
+          const form = new FormData()
+          form.append('avatar', avatarFile)
+          const headers = { Authorization: `Bearer ${data.token}` }
+          const endpoint = server.endsWith('/') ? server + 'api/profile/avatar' : server + '/api/profile/avatar'
+          const avatarResponse = await axios.post(endpoint, form, { headers })
+          if (avatarResponse?.data?.user) {
+            setAuth(data.token, avatarResponse.data.user)
+          }
+        } catch (avatarErr) {
+          console.error(avatarErr)
+        }
+      }
+    } catch (err) {
+      console.error(err)
+      const error = err?.response?.data?.error
+      const message = (() => {
+        switch (error) {
+          case 'username_taken':
+            return 'Такой логин уже используется'
+          case 'weak_password':
+            return 'Пароль должен содержать минимум 8 символов, включая буквы и цифры'
+          case 'invite_expired':
+            return 'Срок действия кода истёк'
+          case 'invite_used':
+            return 'Код уже использован'
+          case 'invite_revoked':
+            return 'Код был отозван'
+          case 'invite_claim_invalid':
+            return 'Проверка кода не пройдена, попробуйте снова'
+          default:
+            break
+        }
+        if (error === 'invite_required' || error === 'invalid_invite') {
+          return 'Для регистрации нужен действующий код приглашения'
+        }
+        return 'Не удалось завершить регистрацию'
+      })()
+      setStatus(message)
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const renderLogin = () => (
+    <form onSubmit={handleLoginSubmit} className="space-y-4">
+      <input
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="Имя пользователя"
+        className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
+        autoComplete="username"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Пароль"
+        className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
+        autoComplete="current-password"
+      />
+      {status && <div className="text-sm text-red-400 text-center">{status}</div>}
+      <button
+        className="w-full bg-white/20 hover:bg-white/30 rounded-2xl py-3 transition disabled:opacity-60"
+        disabled={processing}
+      >
+        Войти
+      </button>
+      <div className="text-sm text-white/70 text-center space-y-2">
+        <div>
+          Новый пользователь?
+          {' '}
+          <button type="button" onClick={() => setMode('invite')} className="underline">
+            У меня есть код приглашения
+          </button>
+        </div>
+      </div>
+    </form>
+  )
+
+  const renderInvite = () => (
+    <form onSubmit={handleInviteSubmit} className="space-y-4">
+      <div className="text-white/80 text-center">Введите полученный код приглашения</div>
+      <input
+        value={inviteCodeInput}
+        onChange={(e) => setInviteCodeInput(e.target.value.toUpperCase())}
+        placeholder="Например, A1B2C3D4"
+        className="w-full uppercase tracking-[0.3em] text-center text-lg bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
+      />
+      {status && <div className="text-sm text-red-400 text-center">{status}</div>}
+      <button
+        className="w-full bg-white/20 hover:bg-white/30 rounded-2xl py-3 transition disabled:opacity-60"
+        disabled={processing}
+      >
+        Проверить код
+      </button>
+      <div className="text-sm text-white/60 text-center">
+        <button type="button" onClick={goToLogin} className="underline">
+          Вернуться к входу
+        </button>
+      </div>
+    </form>
+  )
+
+  const renderRegister = () => {
+    const expiresAt = inviteInfo?.expiresAt ? formatDateTime(inviteInfo.expiresAt) : null
+    const inviter = inviteInfo?.createdBy?.username
+    return (
+      <form onSubmit={handleRegisterSubmit} className="space-y-4">
+        <div className="space-y-2 text-sm text-white/70">
+          <div className="flex items-center justify-between bg-white/5 border border-white/10 rounded-2xl px-4 py-3">
+            <div>
+              <div className="uppercase text-xs tracking-[0.3em] text-white/40">Код</div>
+              <div className="text-lg tracking-[0.25em] text-white/90">{inviteInfo?.code}</div>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setInviteInfo(null)
+                setInviteCodeInput('')
+                setMode('invite')
+              }}
+              className="text-xs underline text-white/60"
+            >
+              Изменить код
+            </button>
+          </div>
+          {inviter && <div>Пригласил: <span className="text-white/90">{inviter}</span></div>}
+          {expiresAt && <div>Действует до: <span className="text-white/90">{expiresAt}</span></div>}
+        </div>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Имя пользователя"
+          className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
+          autoComplete="username"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Пароль (мин. 8 символов, буквы и цифры)"
+          className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
+          autoComplete="new-password"
+        />
+        <input
+          type="password"
+          value={passwordConfirm}
+          onChange={(e) => setPasswordConfirm(e.target.value)}
+          placeholder="Повторите пароль"
+          className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
+          autoComplete="new-password"
+        />
+        <div className="bg-white/5 border border-white/15 rounded-2xl px-4 py-4 text-sm text-white/70 space-y-3">
+          <div className="text-white/80 text-sm">Выберите аватар (необязательно)</div>
+          <div className="flex flex-col gap-3">
+            <input type="file" accept="image/*" onChange={handleAvatarChange} className="text-white/60" />
+            {avatarPreview && (
+              <div className="flex items-center gap-3">
+                <img src={avatarPreview} alt="Предпросмотр аватара" className="w-16 h-16 rounded-full object-cover border border-white/20" />
+                <button type="button" onClick={resetAvatar} className="text-xs underline text-white/60">
+                  Удалить
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+        {status && <div className="text-sm text-red-400 text-center">{status}</div>}
+        <button
+          className="w-full bg-emerald-500/80 hover:bg-emerald-500 rounded-2xl py-3 transition disabled:opacity-60"
+          disabled={processing}
+        >
+          Завершить регистрацию
+        </button>
+        <div className="text-sm text-white/60 text-center">
+          <button type="button" onClick={goToLogin} className="underline">
+            Уже есть аккаунт? Войти
+          </button>
+        </div>
+      </form>
+    )
+  }
+
+  const renderContent = () => {
+    if (mode === 'invite') return renderInvite()
+    if (mode === 'register') return renderRegister()
+    return renderLogin()
+  }
 
   return (
     <div className="h-[calc(100%-48px)] flex items-center justify-center relative">
@@ -39,46 +362,11 @@ export default function Login() {
       </div>
       <div className="glass p-10 rounded-3xl w-[520px] border-white/15 relative">
         <h1 className="text-2xl mb-6 tracking-widest text-white/90 text-center">
-          Добро пожаловать в NE Messenger
+          {mode === 'login' && 'Добро пожаловать в NE Messenger'}
+          {mode === 'invite' && 'Регистрация по приглашению'}
+          {mode === 'register' && 'Создание аккаунта'}
         </h1>
-        <form onSubmit={submit} className="space-y-4">
-          <input
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            placeholder="Имя пользователя"
-            className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
-          />
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Пароль"
-            className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
-          />
-          {status && <div className="text-sm text-red-400 text-center">{status}</div>}
-          <button className="w-full bg-white/20 hover:bg-white/30 rounded-2xl py-3 transition">
-            {isLogin ? 'Войти' : 'Создать аккаунт'}
-          </button>
-          <div className="text-sm text-white/70 text-center">
-            {isLogin ? (
-              <span>
-                Нет аккаунта?
-                {' '}
-                <button type="button" onClick={() => setMode('register')} className="underline">
-                  Зарегистрируйтесь
-                </button>
-              </span>
-            ) : (
-              <span>
-                Уже есть аккаунт?
-                {' '}
-                <button type="button" onClick={() => setMode('login')} className="underline">
-                  Войдите
-                </button>
-              </span>
-            )}
-          </div>
-        </form>
+        {renderContent()}
       </div>
     </div>
   )

--- a/client/src/ui/Profile.jsx
+++ b/client/src/ui/Profile.jsx
@@ -8,6 +8,10 @@ export default function Profile() {
   const updateAvatar = useStore((s) => s.updateAvatar)
   const changePassword = useStore((s) => s.changePassword)
   const buildAvatarUrl = useStore((s) => s.buildAvatarUrl)
+  const invites = useStore((s) => s.invites) ?? []
+  const fetchInvites = useStore((s) => s.fetchInvites)
+  const createInvite = useStore((s) => s.createInvite)
+  const revokeInvite = useStore((s) => s.revokeInvite)
   const audioDevices = useStore((s) => s.audioDevices)
   const audioInputDeviceId = useStore((s) => s.audioInputDeviceId)
   const audioOutputDeviceId = useStore((s) => s.audioOutputDeviceId)
@@ -23,6 +27,13 @@ export default function Profile() {
   const [newPassword, setNewPassword] = useState('')
   const [passwordStatus, setPasswordStatus] = useState(null)
   const [deviceStatus, setDeviceStatus] = useState(null)
+  const [inviteTtl, setInviteTtl] = useState('604800000')
+  const [inviteActionStatus, setInviteActionStatus] = useState(null)
+  const [inviteLoading, setInviteLoading] = useState(false)
+  const [revokeInviteId, setRevokeInviteId] = useState(null)
+  const [copiedInviteId, setCopiedInviteId] = useState(null)
+  const inviteStatusTimerRef = useRef(null)
+  const inviteCopyTimerRef = useRef(null)
 
   useEffect(() => () => {
     if (avatarPreview) URL.revokeObjectURL(avatarPreview)
@@ -31,6 +42,19 @@ export default function Profile() {
   useEffect(() => {
     refreshAudioDevices()
   }, [refreshAudioDevices])
+
+  useEffect(() => {
+    if (!user) return
+    fetchInvites().catch((err) => console.error(err))
+  }, [user, fetchInvites])
+
+  useEffect(
+    () => () => {
+      if (inviteStatusTimerRef.current) clearTimeout(inviteStatusTimerRef.current)
+      if (inviteCopyTimerRef.current) clearTimeout(inviteCopyTimerRef.current)
+    },
+    [],
+  )
 
   const handleAvatarSelect = (event) => {
     const file = event.target.files?.[0]
@@ -82,6 +106,94 @@ export default function Profile() {
     setAvatarFile(null)
     setAvatarStatus(null)
     if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const inviteStatusLabels = {
+    active: 'Активен',
+    claimed: 'Ожидает регистрации',
+    used: 'Использован',
+    expired: 'Просрочен',
+    revoked: 'Отозван',
+  }
+
+  const formatInviteDate = (value) => {
+    if (!value) return ''
+    try {
+      return new Date(value).toLocaleString('ru-RU')
+    } catch (err) {
+      console.error('invite date format failed', err)
+      return ''
+    }
+  }
+
+  const showInviteStatus = (payload) => {
+    if (inviteStatusTimerRef.current) clearTimeout(inviteStatusTimerRef.current)
+    setInviteActionStatus(payload)
+    if (payload) {
+      inviteStatusTimerRef.current = setTimeout(() => setInviteActionStatus(null), 4000)
+    }
+  }
+
+  const handleCreateInvite = async () => {
+    showInviteStatus(null)
+    setInviteLoading(true)
+    try {
+      const ttlMs = parseInt(inviteTtl, 10)
+      const invite = await createInvite(Number.isFinite(ttlMs) ? ttlMs : undefined)
+      if (invite) {
+        let message = `Создан новый код: ${invite.code}`
+        try {
+          if (navigator?.clipboard?.writeText) {
+            await navigator.clipboard.writeText(invite.code)
+            setCopiedInviteId(invite.id)
+            if (inviteCopyTimerRef.current) clearTimeout(inviteCopyTimerRef.current)
+            inviteCopyTimerRef.current = setTimeout(() => setCopiedInviteId(null), 2000)
+            message = `Код ${invite.code} скопирован в буфер обмена`
+          }
+        } catch (copyErr) {
+          console.error(copyErr)
+        }
+        showInviteStatus({ type: 'success', message })
+      }
+    } catch (err) {
+      console.error(err)
+      showInviteStatus({ type: 'error', message: 'Не удалось создать код приглашения' })
+    } finally {
+      setInviteLoading(false)
+    }
+  }
+
+  const handleCopyInvite = async (invite) => {
+    if (!invite?.code) return
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(invite.code)
+        setCopiedInviteId(invite.id)
+        if (inviteCopyTimerRef.current) clearTimeout(inviteCopyTimerRef.current)
+        inviteCopyTimerRef.current = setTimeout(() => setCopiedInviteId(null), 2000)
+        showInviteStatus({ type: 'success', message: `Код ${invite.code} скопирован` })
+      } else {
+        showInviteStatus({ type: 'info', message: `Код: ${invite.code}` })
+      }
+    } catch (err) {
+      console.error(err)
+      showInviteStatus({ type: 'error', message: 'Не удалось скопировать код' })
+    }
+  }
+
+  const handleRevokeInvite = async (invite) => {
+    if (!invite) return
+    setRevokeInviteId(invite.id)
+    showInviteStatus(null)
+    try {
+      await revokeInvite(invite.id)
+      showInviteStatus({ type: 'success', message: `Код ${invite.code} отозван` })
+    } catch (err) {
+      console.error(err)
+      showInviteStatus({ type: 'error', message: 'Не удалось отозвать код' })
+    } finally {
+      setRevokeInviteId(null)
+    }
   }
 
   const handleRefreshDevices = async () => {
@@ -187,6 +299,99 @@ export default function Profile() {
           <div><span className="text-white/40">Имя пользователя:</span> @{user.username}</div>
           <div><span className="text-white/40">ID:</span> {user.id}</div>
           <div><span className="text-white/40">Роль:</span> {roleLabel}</div>
+        </div>
+      </section>
+
+      <section className="panel rounded-3xl px-6 py-5 space-y-4">
+        <div className="text-white/70 text-xs uppercase tracking-[0.25em]">Приглашения</div>
+        <div className="space-y-4 text-sm">
+          <div className="flex flex-col sm:flex-row sm:items-end gap-3">
+            <div className="flex-1">
+              <label className="text-xs uppercase tracking-[0.2em] text-white/50 block mb-2">Срок действия</label>
+              <select
+                value={inviteTtl}
+                onChange={(e) => setInviteTtl(e.target.value)}
+                className="w-full bg-white/5 border border-white/15 rounded-2xl px-4 py-3 outline-none focus:bg-white/10"
+              >
+                <option value="86400000">24 часа</option>
+                <option value="604800000">7 дней</option>
+                <option value="1209600000">14 дней</option>
+              </select>
+            </div>
+            <button
+              type="button"
+              onClick={handleCreateInvite}
+              disabled={inviteLoading}
+              className="px-4 py-3 rounded-2xl bg-white/15 hover:bg-white/25 transition disabled:opacity-60"
+            >
+              Создать код
+            </button>
+          </div>
+          {inviteActionStatus && (
+            <div
+              className={`text-center ${
+                inviteActionStatus.type === 'success'
+                  ? 'text-emerald-400'
+                  : inviteActionStatus.type === 'error'
+                  ? 'text-red-400'
+                  : 'text-white/70'
+              }`}
+            >
+              {inviteActionStatus.message}
+            </div>
+          )}
+          <div className="space-y-3">
+            {invites.length === 0 ? (
+              <div className="text-white/50 text-sm">
+                Кодов пока нет. Создайте первый, чтобы пригласить друзей.
+              </div>
+            ) : (
+              invites.map((invite) => {
+                const statusLabel = inviteStatusLabels[invite.status] ?? invite.status
+                const expiresAt = formatInviteDate(invite.expiresAt)
+                const claimedAt = invite.status === 'claimed' ? formatInviteDate(invite.claimedAt) : ''
+                const usedAt = invite.status === 'used' ? formatInviteDate(invite.usedAt) : ''
+                const canRevoke = invite.status === 'active' || invite.status === 'claimed'
+                return (
+                  <div
+                    key={invite.id}
+                    className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 bg-white/5 border border-white/10 rounded-2xl px-4 py-4"
+                  >
+                    <div className="space-y-1 text-sm">
+                      <div className="text-lg tracking-[0.3em] text-white/90">{invite.code}</div>
+                      <div className="text-xs uppercase tracking-[0.2em] text-white/40">
+                        Статус:
+                        {' '}
+                        <span className="text-white/70 normal-case">{statusLabel}</span>
+                      </div>
+                      {expiresAt && <div className="text-white/50 text-xs">Действует до: {expiresAt}</div>}
+                      {claimedAt && <div className="text-white/50 text-xs">Код зарезервирован: {claimedAt}</div>}
+                      {usedAt && <div className="text-white/50 text-xs">Использован: {usedAt}</div>}
+                    </div>
+                    <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+                      <button
+                        type="button"
+                        onClick={() => handleCopyInvite(invite)}
+                        className="px-3 py-2 rounded-xl bg-white/10 hover:bg-white/20 transition text-sm disabled:opacity-60"
+                      >
+                        {copiedInviteId === invite.id ? 'Скопировано' : 'Скопировать'}
+                      </button>
+                      {canRevoke && (
+                        <button
+                          type="button"
+                          onClick={() => handleRevokeInvite(invite)}
+                          disabled={revokeInviteId === invite.id}
+                          className="px-3 py-2 rounded-xl bg-red-500/20 hover:bg-red-500/30 transition text-sm disabled:opacity-60"
+                        >
+                          Отозвать
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </div>
         </div>
       </section>
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -218,7 +218,8 @@ CREATE TABLE IF NOT EXISTS invites (
   claim_token TEXT DEFAULT '',
   claimed_at INTEGER,
   used_by TEXT,
-  used_at INTEGER
+  used_at INTEGER,
+  revoked_at INTEGER
 );
 `)
 
@@ -252,6 +253,9 @@ try {
 try {
   db.prepare('ALTER TABLE invites ADD COLUMN used_at INTEGER').run()
 } catch (err) {}
+try {
+  db.prepare('ALTER TABLE invites ADD COLUMN revoked_at INTEGER').run()
+} catch (err) {}
 
 db.prepare('UPDATE users SET avatar_seed = COALESCE(avatar_seed, substr(username,1,2))').run()
 
@@ -264,13 +268,16 @@ const listVoiceRoomsStmt = db.prepare('SELECT id, name, created_at, created_by F
 const insertVoiceRoomStmt = db.prepare('INSERT INTO voice_rooms (id, name, created_at, created_by) VALUES (?,?,?,?)')
 const deleteVoiceRoomStmt = db.prepare('DELETE FROM voice_rooms WHERE id=?')
 const selectVoiceRoomStmt = db.prepare('SELECT id, name FROM voice_rooms WHERE id=?')
-const insertInviteStmt = db.prepare('INSERT INTO invites (id, code, created_by, created_at, expires_at, claim_token, claimed_at, used_by, used_at) VALUES (?,?,?,?,?,?,NULL,NULL,NULL)')
+const insertInviteStmt = db.prepare(
+  'INSERT INTO invites (id, code, created_by, created_at, expires_at, claim_token, claimed_at, used_by, used_at, revoked_at) VALUES (?,?,?,?,?, ?, NULL, NULL, NULL, NULL)'
+)
 const selectInviteByCodeStmt = db.prepare('SELECT * FROM invites WHERE code=?')
 const selectInviteByIdStmt = db.prepare('SELECT * FROM invites WHERE id=?')
 const listInvitesByCreatorStmt = db.prepare('SELECT * FROM invites WHERE created_by=? ORDER BY created_at DESC')
 const updateInviteClaimStmt = db.prepare('UPDATE invites SET claim_token=?, claimed_at=? WHERE id=?')
 const clearInviteClaimStmt = db.prepare('UPDATE invites SET claim_token="", claimed_at=NULL WHERE id=?')
-const markInviteUsedStmt = db.prepare("UPDATE invites SET used_by=?, used_at=?, claim_token='' WHERE id=?")
+const markInviteUsedStmt = db.prepare("UPDATE invites SET used_by=?, used_at=?, claim_token='', revoked_at=NULL WHERE id=?")
+const revokeInviteStmt = db.prepare('UPDATE invites SET revoked_at=?, claim_token="" WHERE id=?')
 const findMessageById = db.prepare('SELECT id, channel_id, sender_id FROM messages WHERE id=?')
 const deleteMessageStmt = db.prepare('DELETE FROM messages WHERE id=?')
 
@@ -376,14 +383,95 @@ const adminOnly = (req, res, next) => {
   return res.status(403).json({ error: 'forbidden' })
 }
 
+app.post('/api/invites/claim', (req, res) => {
+  const codeRaw = typeof req.body?.code === 'string' ? req.body.code : ''
+  const code = codeRaw.trim().toUpperCase()
+  if (!code) {
+    warn('[INVITES] claim missing code')
+    return res.status(400).json({ error: 'code_required' })
+  }
+  const invite = selectInviteByCodeStmt.get(code)
+  if (!invite) {
+    warn('[INVITES] claim invalid code', code)
+    return res.status(400).json({ error: 'invalid_code' })
+  }
+  const now = Date.now()
+  if (invite.revoked_at) {
+    warn('[INVITES] claim revoked', code)
+    return res.status(400).json({ error: 'invite_revoked' })
+  }
+  if (invite.used_by) {
+    warn('[INVITES] claim used', code)
+    return res.status(400).json({ error: 'invite_used' })
+  }
+  if (invite.expires_at && invite.expires_at < now) {
+    warn('[INVITES] claim expired', code)
+    return res.status(400).json({ error: 'invite_expired' })
+  }
+  const claimToken = generateClaimToken()
+  updateInviteClaimStmt.run(claimToken, now, invite.id)
+  const updated = selectInviteByIdStmt.get(invite.id)
+  const creator = selectUserById.get(invite.created_by)
+  const creatorInfo = creator ? { id: creator.id, username: creator.username } : { id: '', username: '' }
+  log('[INVITES] claimed', code, 'by_ip=' + req.ip)
+  res.json({
+    invite: {
+      code: updated.code,
+      createdAt: updated.created_at,
+      expiresAt: updated.expires_at,
+      status: getInviteStatus(updated),
+      createdBy: creatorInfo,
+    },
+    claimToken,
+  })
+})
+
 app.post('/api/register', (req, res) => {
-  const { username, password } = req.body || {}
+  const { username: rawUsername, password: rawPassword, inviteCode: rawInviteCode, inviteClaimToken } = req.body || {}
+  const username = typeof rawUsername === 'string' ? rawUsername.trim() : ''
+  const password = typeof rawPassword === 'string' ? rawPassword : ''
   if (!username || !password) {
     warn('[REGISTER] invalid payload', req.ip)
-    return res.status(400).json({ error: 'username and password required' })
+    return res.status(400).json({ error: 'username_and_password_required' })
+  }
+  if (password.length < 8 || !/[A-Za-z]/.test(password) || !/[0-9]/.test(password)) {
+    warn('[REGISTER] weak password', username)
+    return res.status(400).json({ error: 'weak_password' })
   }
   log('[REGISTER] attempt', username, 'ip=' + req.ip)
-  const isFirstUser = !db.prepare('SELECT 1 FROM users LIMIT 1').get()
+  const firstUserExists = db.prepare('SELECT 1 FROM users LIMIT 1').get()
+  const isFirstUser = !firstUserExists
+  let invite = null
+  if (!isFirstUser) {
+    const inviteCode = typeof rawInviteCode === 'string' ? rawInviteCode.trim().toUpperCase() : ''
+    const claimToken = typeof inviteClaimToken === 'string' ? inviteClaimToken.trim() : ''
+    if (!inviteCode || !claimToken) {
+      warn('[REGISTER] invite required missing data', username)
+      return res.status(400).json({ error: 'invite_required' })
+    }
+    invite = selectInviteByCodeStmt.get(inviteCode)
+    if (!invite) {
+      warn('[REGISTER] invalid invite', inviteCode)
+      return res.status(400).json({ error: 'invalid_invite' })
+    }
+    const now = Date.now()
+    if (invite.revoked_at) {
+      warn('[REGISTER] invite revoked', inviteCode)
+      return res.status(400).json({ error: 'invite_revoked' })
+    }
+    if (invite.used_by) {
+      warn('[REGISTER] invite already used', inviteCode)
+      return res.status(400).json({ error: 'invite_used' })
+    }
+    if (invite.expires_at && invite.expires_at < now) {
+      warn('[REGISTER] invite expired', inviteCode)
+      return res.status(400).json({ error: 'invite_expired' })
+    }
+    if (!invite.claim_token || invite.claim_token !== claimToken) {
+      warn('[REGISTER] invite claim mismatch', inviteCode)
+      return res.status(400).json({ error: 'invite_claim_invalid' })
+    }
+  }
   const id = uuidv4()
   const hash = bcrypt.hashSync(password, 10)
   const role = isFirstUser ? 'admin' : 'user'
@@ -395,9 +483,12 @@ app.post('/api/register', (req, res) => {
     return res.status(400).json({ error: 'username_taken' })
   }
   db.prepare('INSERT OR IGNORE INTO workspace_members (workspace_id,user_id) VALUES (?,?)').run(defaultWs.id, id)
+  if (invite) {
+    markInviteUsedStmt.run(id, Date.now(), invite.id)
+  }
   const token = jwt.sign({ id, username, role, avatar_seed: avatarSeed }, JWT_SECRET, { expiresIn: '30d' })
   const user = publicUser({ id, username, role, avatar_seed: avatarSeed })
-  log('[REGISTER] success', username, 'role=' + role)
+  log('[REGISTER] success', username, 'role=' + role, invite ? 'invite=' + invite.code : 'no_invite')
   res.json({ token, user })
   io.emit('user:update', user)
 })
@@ -418,6 +509,49 @@ app.post('/api/login', (req, res) => {
   const token = jwt.sign({ id: userRecord.id, username: userRecord.username, role: userRecord.role, avatar_seed: userRecord.avatar_seed || '' }, JWT_SECRET, { expiresIn: '30d' })
   log('[LOGIN] success', username)
   res.json({ token, user: publicUser(userRecord) })
+})
+
+app.get('/api/invites', auth, (req, res) => {
+  const invites = listInvitesByCreatorStmt.all(req.user.id).map(formatInvite)
+  log('[INVITES] list', 'user=' + req.user.id, 'count=' + invites.length)
+  res.json({ invites })
+})
+
+app.post('/api/invites', auth, (req, res) => {
+  const maxTtl = 1000 * 60 * 60 * 24 * 30
+  let ttlMs = parseInt(req.body?.ttlMs, 10)
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) ttlMs = INVITE_DEFAULT_TTL
+  if (ttlMs > maxTtl) ttlMs = maxTtl
+  const now = Date.now()
+  const id = uuidv4()
+  const code = generateInviteCode()
+  insertInviteStmt.run(id, code, req.user.id, now, now + ttlMs, '')
+  const invite = selectInviteByIdStmt.get(id)
+  log('[INVITES] create', code, 'user=' + req.user.id, 'ttl=' + ttlMs)
+  res.status(201).json({ invite: formatInvite(invite) })
+})
+
+app.post('/api/invites/:id/revoke', auth, (req, res) => {
+  const invite = selectInviteByIdStmt.get(req.params.id)
+  if (!invite) {
+    warn('[INVITES] revoke missing', req.params.id)
+    return res.status(404).json({ error: 'not_found' })
+  }
+  if (invite.created_by !== req.user.id && req.user.role !== 'admin') {
+    warn('[INVITES] revoke forbidden', 'user=' + req.user.id, 'target=' + invite.id)
+    return res.status(403).json({ error: 'forbidden' })
+  }
+  if (invite.used_by) {
+    warn('[INVITES] revoke used', invite.code)
+    return res.status(400).json({ error: 'invite_used' })
+  }
+  if (invite.revoked_at) {
+    return res.status(400).json({ error: 'invite_revoked' })
+  }
+  revokeInviteStmt.run(Date.now(), invite.id)
+  const updated = selectInviteByIdStmt.get(invite.id)
+  log('[INVITES] revoked', invite.code, 'by=' + req.user.id)
+  res.json({ invite: formatInvite(updated) })
 })
 
 app.get('/api/users', auth, (req, res) => {
@@ -830,9 +964,18 @@ const generateInviteCode = (length = INVITE_CODE_LENGTH) => {
   return code
 }
 
+const generateClaimToken = () =>
+  crypto
+    .randomBytes(24)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+
 const getInviteStatus = (invite) => {
   const now = Date.now()
   if (invite.used_by) return 'used'
+  if (invite.revoked_at) return 'revoked'
   if (invite.expires_at && invite.expires_at < now) return 'expired'
   if (invite.claim_token) return 'claimed'
   return 'active'
@@ -847,6 +990,7 @@ const formatInvite = (invite) => ({
   claimedAt: invite.claimed_at || 0,
   usedAt: invite.used_at || 0,
   usedBy: invite.used_by || '',
+  revokedAt: invite.revoked_at || 0,
   status: getInviteStatus(invite),
 })
 


### PR DESCRIPTION
## Summary
- add invite management endpoints, schema updates, and enforce invite validation during registration with stronger password policy
- extend client state with invite actions and rebuild login into a multi-step invite-based onboarding with avatar upload option
- expose invite creation and management tools in the profile screen for existing users

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68d46437470c83248494f5ddfc432d94