### PR TITLE
Ensure voice room lookups return created_at

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -356,7 +356,7 @@ const listVoiceRoomsForUserStmt = db.prepare(
 const insertVoiceRoomStmt = db.prepare('INSERT INTO voice_rooms (id, name, created_at, created_by) VALUES (?,?,?,?)')
 const deleteVoiceRoomStmt = db.prepare('DELETE FROM voice_rooms WHERE id=?')
 
-const selectVoiceRoomStmt = db.prepare('SELECT id, name, created_by FROM voice_rooms WHERE id=?')
+const selectVoiceRoomStmt = db.prepare('SELECT id, name, created_at, created_by FROM voice_rooms WHERE id=?')
 const insertVoiceRoomMemberStmt = db.prepare(
   'INSERT OR REPLACE INTO voice_room_members (room_id, user_id, role, added_at, added_by) VALUES (?,?,?,?,?)'
 )


### PR DESCRIPTION
## Summary
- include the created_at column when selecting a voice room so downstream formatters receive the timestamp

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d6c5d9a3f48324b781deda03456096