### PR TITLE
Remove duplicated private channel logic in sidebar

### DIFF
--- a/client/src/ui/Sidebar.jsx
+++ b/client/src/ui/Sidebar.jsx
@@ -34,6 +34,7 @@ export default function Sidebar() {
   const voiceSelfSocketId = useStore((s) => s.voiceSelfSocketId)
   const updateVoiceRoomMembers = useStore((s) => s.updateVoiceRoomMembers)
 
+  const [searchTerm, setSearchTerm] = useState('')
 
   const onlineSet = useMemo(() => new Set(onlineUserIds), [onlineUserIds])
   const otherUsers = useMemo(() => users.filter((u) => u.id !== me?.id), [users, me])
@@ -63,7 +64,6 @@ export default function Sidebar() {
   const [selectedIds, setSelectedIds] = useState([])
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState(null)
-  const [searchTerm, setSearchTerm] = useState('')
   const [voiceDialogOpen, setVoiceDialogOpen] = useState(false)
   const [voiceName, setVoiceName] = useState('')
   const [voiceSelectedIds, setVoiceSelectedIds] = useState([])
@@ -163,44 +163,6 @@ export default function Sidebar() {
       setVoiceSaving(false)
     }
 
-  }
-
-  const [createDialogOpen, setCreateDialogOpen] = useState(false)
-  const [channelName, setChannelName] = useState('')
-  const [selectedIds, setSelectedIds] = useState([])
-  const [creating, setCreating] = useState(false)
-  const [createError, setCreateError] = useState(null)
-
-  const toggleSelection = (userId) => {
-    setSelectedIds((current) => (current.includes(userId) ? current.filter((id) => id !== userId) : [...current, userId]))
-  }
-
-  const closeCreateDialog = () => {
-    if (creating) return
-    setCreateDialogOpen(false)
-    setChannelName('')
-    setSelectedIds([])
-    setCreateError(null)
-  }
-
-  const handleCreatePrivateChannel = async () => {
-    if (creating) return
-    if (!channelName.trim()) {
-      setCreateError('Введите название канала')
-      return
-    }
-    setCreating(true)
-    setCreateError(null)
-    try {
-      const channel = await createPrivateChannel(channelName, selectedIds)
-      if (channel?.id) switchChannel(channel.id)
-      closeCreateDialog()
-    } catch (err) {
-      console.error('create private channel failed', err)
-      setCreateError('Не удалось создать канал')
-    } finally {
-      setCreating(false)
-    }
   }
 
   return (
@@ -316,7 +278,12 @@ export default function Sidebar() {
               filteredPrivateChannels.map((channel) => {
                 const active = channel.id === activeChannelId
                 const unreadCount = unread[channel.id] || 0
-                const role = channel.membershipRole === 'owner' ? 'Создатель' : channel.membershipRole === 'admin' ? 'Админ' : 'Участник'
+                const role =
+                  channel.membershipRole === 'owner'
+                    ? 'Создатель'
+                    : channel.membershipRole === 'admin'
+                      ? 'Админ'
+                      : 'Участник'
                 return (
                   <button
                     key={channel.id}
@@ -342,52 +309,9 @@ export default function Sidebar() {
             ) : (
               <div className="text-sm text-white/40 px-2">Приватных комнат пока нет</div>
             )
-
           ) : (
             <div className="text-xs text-white/30 px-2">Секция скрыта</div>
           )}
-          })}
-          {publicChannels.length === 0 && <div className="text-sm text-white/40 px-2">Общих каналов пока нет</div>}
-        </div>
-
-        <div className="space-y-2">
-          <div className="px-2 text-xs uppercase tracking-[0.2em] text-white/40 flex items-center justify-between">
-            <span>Приватные комнаты</span>
-            <button
-              type="button"
-              onClick={() => setCreateDialogOpen(true)}
-              className="text-white/40 hover:text-white/80 transition text-lg leading-none"
-            >
-              +
-            </button>
-          </div>
-          {privateChannels.map((channel) => {
-            const active = channel.id === activeChannelId
-            const unreadCount = unread[channel.id] || 0
-            const role = channel.membershipRole === 'owner' ? 'Создатель' : channel.membershipRole === 'admin' ? 'Админ' : 'Участник'
-            return (
-              <button
-                key={channel.id}
-                type="button"
-                onClick={() => switchChannel(channel.id)}
-                className={`w-full flex items-center justify-between px-3 py-3 rounded-2xl transition-colors ${active ? 'panel' : 'glass hover:bg-white/10'}`}
-              >
-                <div className="flex items-center gap-3">
-                  <div className="avatar">🔒</div>
-                  <div>
-                    <div className="text-sm font-medium">{channel.name}</div>
-                    <div className="text-xs text-white/60 flex items-center gap-2">
-                      <span>{role}</span>
-                      <span>•</span>
-                      <span>{channel.memberCount} участн.</span>
-                    </div>
-                  </div>
-                </div>
-                {unreadCount > 0 && <span className="badge">{unreadCount}</span>}
-              </button>
-            )
-          })}
-          {privateChannels.length === 0 && <div className="text-sm text-white/40 px-2">Приватных комнат пока нет</div>}
         </div>
 
         <div>


### PR DESCRIPTION
## Summary
- remove the duplicated private-channel state hooks in the sidebar component
- delete the second rendering pass of the private channel list so it only renders once
- move the search term state above derived memo usage to avoid runtime errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6ca7bce5883249ca55f19a7dda8a3