### PR TITLE
Handle undefined editing voice room data

### DIFF
--- a/client/src/ui/Sidebar.jsx
+++ b/client/src/ui/Sidebar.jsx
@@ -76,6 +76,11 @@ export default function Sidebar() {
   const [showUsers, setShowUsers] = useState(true)
   const [showVoice, setShowVoice] = useState(true)
 
+  const editingCount =
+    editingRoom?.participantCount ??
+    (editingRoom ? voiceParticipantsCount(editingRoom.id) : undefined)
+  const editingActive = editingRoom ? activeVoiceRoomId === editingRoom.id : false
+
   const toggleSelection = (userId) => {
     setSelectedIds((current) => (current.includes(userId) ? current.filter((id) => id !== userId) : [...current, userId]))
   }
@@ -626,8 +631,8 @@ export default function Sidebar() {
 
                     <span className="text-[11px] text-white/40">Создатель</span>
 
-                    <div className="text-xs text-white/50">В голосе: {count}</div>
-                    {active && voiceStatus && (
+                    <div className="text-xs text-white/50">В голосе: {editingCount ?? 0}</div>
+                    {editingActive && voiceStatus && (
                       <div className="text-[11px] text-white/40">
                         {voiceStatus === 'connecting'
                           ? 'Подключение...'


### PR DESCRIPTION
## Summary
- calculate the participant count and active state for the editing voice room before rendering the creator block
- render the editing room creator info with safe fallbacks to avoid crashes when data is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6d3155d148324884740d250b58304