### PR TITLE
Prevent titlebar drag on interactive controls

### DIFF
--- a/client/src/ui/Titlebar.jsx
+++ b/client/src/ui/Titlebar.jsx
@@ -95,6 +95,7 @@ export default function Titlebar() {
 
   const handleMouseDown = (event) => {
     if (event.button !== 0) return
+    if (event.target.closest?.('.no-drag')) return
     if (!api?.beginDrag) return
     const screenX = window.screenX + event.clientX
     const screenY = window.screenY + event.clientY


### PR DESCRIPTION
## Summary
- prevent the titlebar drag handler from running when the click originates inside a `.no-drag` element so interactive controls behave correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6d557a7148324a857cde61d9841c5