### PR TITLE
Add private channel deletion workflow

### DIFF
--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -981,6 +981,68 @@ const useStore = create((set, get) => ({
     return channel
   },
 
+  deleteChannel: async (channelId) => {
+    const token = get().token
+    if (!token) throw new Error('not_authenticated')
+    if (!channelId) throw new Error('invalid_channel')
+    await axios.delete(`${get().serverUrl}/api/channels/${channelId}`, {
+      headers: buildAuthHeaders(token),
+    })
+    set((state) => {
+      const patch = {}
+      let changed = false
+      const nextChannels = state.channels.filter((channel) => channel.id !== channelId)
+      const channelExists = nextChannels.length !== state.channels.length
+      if (channelExists) {
+        patch.channels = nextChannels
+        changed = true
+      }
+      const removeEntry = (collection) => {
+        if (!collection || typeof collection !== 'object') return null
+        if (!Object.prototype.hasOwnProperty.call(collection, channelId)) return null
+        const next = { ...collection }
+        delete next[channelId]
+        return next
+      }
+      const nextMessages = removeEntry(state.messages)
+      if (nextMessages) {
+        patch.messages = nextMessages
+        changed = true
+      }
+      const nextUnread = removeEntry(state.unread)
+      if (nextUnread) {
+        patch.unread = nextUnread
+        changed = true
+      }
+      const nextHistoryLoading = removeEntry(state.historyLoading)
+      if (nextHistoryLoading) {
+        patch.historyLoading = nextHistoryLoading
+        changed = true
+      }
+      const nextHistoryComplete = removeEntry(state.historyComplete)
+      if (nextHistoryComplete) {
+        patch.historyComplete = nextHistoryComplete
+        changed = true
+      }
+      const nextTyping = removeEntry(state.typing)
+      if (nextTyping) {
+        patch.typing = nextTyping
+        changed = true
+      }
+      const nextChannelMembers = removeEntry(state.channelMembers)
+      if (nextChannelMembers) {
+        patch.channelMembers = nextChannelMembers
+        changed = true
+      }
+      if (state.activeChannelId === channelId) {
+        patch.activeChannelId = nextChannels[0]?.id || null
+        changed = true
+      }
+      return changed ? patch : state
+    })
+    return true
+  },
+
   fetchChannelMembers: async (channelId) => {
     const token = get().token
     if (!token) throw new Error('not_authenticated')

--- a/client/src/ui/Chat.jsx
+++ b/client/src/ui/Chat.jsx
@@ -532,6 +532,7 @@ export default function Chat() {
   const fetchChannelMembers = useStore((s) => s.fetchChannelMembers)
   const addChannelMember = useStore((s) => s.addChannelMember)
   const removeChannelMember = useStore((s) => s.removeChannelMember)
+  const deleteChannel = useStore((s) => s.deleteChannel)
   const typingMap = useStore((s) => s.typing)
   const socket = useStore((s) => s.socket)
 
@@ -544,6 +545,7 @@ export default function Chat() {
   const [membersDialogOpen, setMembersDialogOpen] = useState(false)
   const [membersLoading, setMembersLoading] = useState(false)
   const [membersError, setMembersError] = useState(null)
+  const [channelDeleteState, setChannelDeleteState] = useState({ loading: false, error: null })
   const [selectedNewMembers, setSelectedNewMembers] = useState([])
   const [selfTyping, setSelfTyping] = useState(false)
   const listRef = useRef(null)
@@ -614,11 +616,15 @@ export default function Chat() {
     return users.filter((user) => !existing.has(user.id))
   }, [channelMembers, users, currentChannel?.id, me?.id])
 
+  const deletingChannel = channelDeleteState.loading
+  const membersBusy = membersLoading || deletingChannel
+
   useEffect(() => {
     setMembersDialogOpen(false)
     setMembersError(null)
     setSelectedNewMembers([])
     setMembersLoading(false)
+    setChannelDeleteState({ loading: false, error: null })
   }, [activeChannelId])
 
   useEffect(() => {
@@ -1005,11 +1011,12 @@ export default function Chat() {
   }
 
   const handleSelectedMemberToggle = (userId) => {
+    if (membersBusy) return
     setSelectedNewMembers((current) => (current.includes(userId) ? current.filter((id) => id !== userId) : [...current, userId]))
   }
 
   const handleAddMembers = async () => {
-    if (!currentChannel?.id || !selectedNewMembers.length) return
+    if (!currentChannel?.id || !selectedNewMembers.length || deletingChannel) return
     setMembersLoading(true)
     setMembersError(null)
     try {
@@ -1027,7 +1034,7 @@ export default function Chat() {
   }
 
   const handleRemoveMember = async (userId) => {
-    if (!currentChannel?.id) return
+    if (!currentChannel?.id || deletingChannel) return
     setMembersLoading(true)
     setMembersError(null)
     try {
@@ -1040,6 +1047,24 @@ export default function Chat() {
       setMembersError('Не удалось удалить участника')
     } finally {
       setMembersLoading(false)
+    }
+  }
+
+  const handleDeleteChannel = async () => {
+    if (!currentChannel?.id) return
+    const confirmation = window.confirm(`Удалить канал #${currentChannel.name}? Это действие нельзя отменить.`)
+    if (!confirmation) return
+    setChannelDeleteState({ loading: true, error: null })
+    try {
+      await deleteChannel(currentChannel.id)
+      setChannelDeleteState({ loading: false, error: null })
+      setMembersDialogOpen(false)
+      setMembersError(null)
+      setSelectedNewMembers([])
+      setMembersLoading(false)
+    } catch (err) {
+      console.error('delete channel failed', err)
+      setChannelDeleteState({ loading: false, error: 'Не удалось удалить канал' })
     }
   }
 
@@ -1094,15 +1119,17 @@ export default function Chat() {
     if (!currentChannel?.id) return
     setMembersDialogOpen(true)
     setMembersError(null)
+    setChannelDeleteState({ loading: false, error: null })
     setSelectedNewMembers([])
   }
 
   const closeMembersDialog = () => {
-    if (membersLoading) return
+    if (membersBusy) return
     setMembersDialogOpen(false)
     setMembersError(null)
     setSelectedNewMembers([])
     setMembersLoading(false)
+    setChannelDeleteState({ loading: false, error: null })
   }
 
   const headerTitle = isDirectChannel
@@ -1353,12 +1380,15 @@ export default function Chat() {
                 type="button"
                 onClick={closeMembersDialog}
                 className="text-white/40 hover:text-white/80 transition"
-                disabled={membersLoading}
+                disabled={membersBusy}
               >
                 ✕
               </button>
             </div>
             {membersError && <div className="px-6 py-3 text-sm text-red-300 bg-red-500/10">{membersError}</div>}
+            {channelDeleteState.error && (
+              <div className="px-6 py-3 text-sm text-red-300 bg-red-500/10">{channelDeleteState.error}</div>
+            )}
             <div className="px-6 py-4 space-y-6 max-h-[70vh] overflow-y-auto scroll-thin">
               <div>
                 <div className="text-xs uppercase tracking-[0.2em] text-white/40 mb-2">Текущие участники</div>
@@ -1389,7 +1419,7 @@ export default function Chat() {
                             type="button"
                             onClick={() => handleRemoveMember(entry.user.id)}
                             className="text-xs text-red-300 hover:text-red-200 transition"
-                            disabled={membersLoading}
+                            disabled={membersBusy}
                           >
                             Удалить
                           </button>
@@ -1420,7 +1450,7 @@ export default function Chat() {
                             type="checkbox"
                             checked={checked}
                             onChange={() => handleSelectedMemberToggle(user.id)}
-                            disabled={membersLoading}
+                            disabled={membersBusy}
                           />
                         </label>
                       )
@@ -1432,19 +1462,33 @@ export default function Chat() {
               </div>
             </div>
             <div className="px-6 py-4 border-t border-white/10 flex items-center justify-between gap-3">
-              <div className="text-xs text-white/40">
-                {membersLoading
-                  ? 'Обновление списка...'
-                  : selectedNewMembers.length
-                  ? `${selectedNewMembers.length} выбран(о)`
-                  : ''}
+              <div className="flex items-center gap-3">
+                {canModerateChannel && (
+                  <button
+                    type="button"
+                    onClick={handleDeleteChannel}
+                    className="px-4 py-2 rounded-2xl bg-red-500/80 text-white hover:bg-red-500 transition text-sm disabled:opacity-50"
+                    disabled={membersBusy}
+                  >
+                    {deletingChannel ? 'Удаление...' : 'Удалить канал'}
+                  </button>
+                )}
+                <div className="text-xs text-white/40">
+                  {deletingChannel
+                    ? 'Удаление канала...'
+                    : membersLoading
+                    ? 'Обновление списка...'
+                    : selectedNewMembers.length
+                    ? `${selectedNewMembers.length} выбран(о)`
+                    : ''}
+                </div>
               </div>
               <div className="flex items-center gap-3">
                 <button
                   type="button"
                   onClick={closeMembersDialog}
                   className="px-4 py-2 rounded-2xl bg-white/10 hover:bg-white/20 transition text-sm"
-                  disabled={membersLoading}
+                  disabled={membersBusy}
                 >
                   Закрыть
                 </button>
@@ -1452,7 +1496,7 @@ export default function Chat() {
                   type="button"
                   onClick={handleAddMembers}
                   className="px-4 py-2 rounded-2xl bg-white/80 text-black hover:bg-white transition text-sm disabled:bg-white/40 disabled:text-white/60"
-                  disabled={membersLoading || selectedNewMembers.length === 0}
+                  disabled={membersBusy || selectedNewMembers.length === 0}
                 >
                   {membersLoading ? 'Сохранение...' : 'Добавить'}
                 </button>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -397,6 +397,9 @@ const listChannelMembersDetailedStmt = db.prepare(
 )
 const insertChannelMemberStmt = db.prepare('INSERT OR REPLACE INTO channel_members (channel_id, user_id, role) VALUES (?,?,?)')
 const deleteChannelMemberStmt = db.prepare('DELETE FROM channel_members WHERE channel_id=? AND user_id=?')
+const deleteChannelMembersStmt = db.prepare('DELETE FROM channel_members WHERE channel_id=?')
+const deleteMessagesByChannelStmt = db.prepare('DELETE FROM messages WHERE channel_id=?')
+const deleteChannelStmt = db.prepare('DELETE FROM channels WHERE id=?')
 const findChannelMemberStmt = db.prepare('SELECT role FROM channel_members WHERE channel_id=? AND user_id=?')
 const countChannelMembersStmt = db.prepare('SELECT COUNT(*) as count FROM channel_members WHERE channel_id=?')
 const listAdminsStmt = db.prepare("SELECT id FROM users WHERE role='admin'")
@@ -918,6 +921,31 @@ app.delete('/api/channels/:id/members/:userId', auth, (req, res) => {
   const members = getChannelMembersDetailed(req.params.id)
   log('[CHANNELS] member:remove', req.params.id, 'actor=' + req.user.id, 'target=' + targetId)
   res.json({ members })
+})
+
+app.delete('/api/channels/:id', auth, (req, res) => {
+  const user = selectUserById.get(req.user.id)
+  if (!user) return res.status(404).json({ error: 'not_found' })
+  const channel = selectChannelByIdStmt.get(req.params.id)
+  if (!channel) return res.status(404).json({ error: 'not_found' })
+  if (!channel.is_private) return res.status(400).json({ error: 'not_private' })
+  const isOwner = channel.created_by && channel.created_by === user.id
+  const isAdmin = user.role === 'admin'
+  if (!isOwner && !isAdmin) return res.status(403).json({ error: 'forbidden' })
+  const audience = getChannelAudienceUserIds(channel)
+  const memberRows = listChannelMembersStmt.all(channel.id)
+  const notifyIds = new Set(audience)
+  if (channel.created_by) notifyIds.add(channel.created_by)
+  memberRows.forEach((row) => {
+    if (row?.user_id) notifyIds.add(row.user_id)
+  })
+  notifyIds.forEach((userId) => removeUserFromChannelRoom(channel.id, userId))
+  deleteMessagesByChannelStmt.run(channel.id)
+  deleteChannelMembersStmt.run(channel.id)
+  deleteChannelStmt.run(channel.id)
+  emitChannelListForUsers(audience)
+  log('[CHANNELS] delete', req.params.id, 'actor=' + req.user.id)
+  res.json({ ok: true })
 })
 
 app.get('/api/users', auth, (req, res) => {


### PR DESCRIPTION
## Summary
- add prepared statements and a DELETE /api/channels/:id route that clears channel data and notifies affected users
- expose a deleteChannel client action that calls the API and prunes local channel-related state
- surface a "Удалить канал" control in the members modal with confirmation, loading, and error handling for moderators

## Testing
- `npm --prefix server start` *(fails: bundled better-sqlite3 binary has an invalid ELF header in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e171d69883249880884fa29007ac