### PR TITLE
Add socket reconnection tracking and UI feedback

### DIFF
--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -9,6 +9,10 @@ const storageKeyForChannel = (cid) => `chkey:${cid}`
 const ICE_SERVERS = [{ urls: 'stun:stun.l.google.com:19302' }]
 const voicePeerConnections = new Map()
 const speakingMonitors = new Map()
+const RECONNECT_DELAYS = [5000, 10000, 20000]
+
+let reconnectTimeoutId = null
+let reconnectCountdownIntervalId = null
 
 const ensureAudioContext = () => {
   if (typeof window === 'undefined') return null
@@ -346,6 +350,12 @@ const useStore = create((set, get) => ({
   users: [],
   view: 'chat',
   socket: null,
+  connectionStatus: 'idle',
+  reconnectAttempt: 0,
+  retryAt: null,
+  retryDelay: null,
+  retrySecondsRemaining: null,
+  connectionError: null,
   workspaces: [],
   channels: [],
   activeChannelId: null,
@@ -523,14 +533,140 @@ const useStore = create((set, get) => ({
     if (get().activeVoiceRoomId === roomId) get().leaveVoiceRoom(false)
   },
 
+  cancelReconnectCountdown: () => {
+    if (reconnectTimeoutId) {
+      clearTimeout(reconnectTimeoutId)
+      reconnectTimeoutId = null
+    }
+    if (reconnectCountdownIntervalId) {
+      clearInterval(reconnectCountdownIntervalId)
+      reconnectCountdownIntervalId = null
+    }
+    set((state) => {
+      if (state.retryDelay === null && state.retryAt === null && state.retrySecondsRemaining === null) return state
+      return { retryDelay: null, retryAt: null, retrySecondsRemaining: null }
+    })
+  },
+  beginReconnectCountdown: (delay, message) => {
+    if (!delay) return
+    get().cancelReconnectCountdown()
+    const targetAt = Date.now() + delay
+    set({
+      connectionStatus: 'retrying',
+      retryDelay: delay,
+      retryAt: targetAt,
+      retrySecondsRemaining: Math.ceil(delay / 1000),
+      connectionError: message || null,
+    })
+    reconnectCountdownIntervalId = setInterval(() => {
+      const remainingMs = targetAt - Date.now()
+      const seconds = Math.max(0, Math.ceil(remainingMs / 1000))
+      set((state) => {
+        if (state.connectionStatus !== 'retrying') return state
+        if (state.retrySecondsRemaining === seconds) return state
+        return { retrySecondsRemaining: seconds }
+      })
+      if (seconds <= 0) {
+        clearInterval(reconnectCountdownIntervalId)
+        reconnectCountdownIntervalId = null
+      }
+    }, 250)
+    reconnectTimeoutId = setTimeout(() => {
+      reconnectTimeoutId = null
+      if (reconnectCountdownIntervalId) {
+        clearInterval(reconnectCountdownIntervalId)
+        reconnectCountdownIntervalId = null
+      }
+      if (!get().token) {
+        set({ connectionStatus: 'idle' })
+        return
+      }
+      set((state) => ({
+        retryDelay: null,
+        retryAt: null,
+        retrySecondsRemaining: null,
+        connectionStatus: 'connecting',
+        connectionError: state.connectionError,
+      }))
+      get().connect()
+    }, delay)
+  },
+  triggerReconnectNow: () => {
+    if (!get().token) return
+    const existing = get().socket
+    if (existing) {
+      if (typeof existing.removeAllListeners === 'function') existing.removeAllListeners()
+      if (existing.io?.off) existing.io.off('close')
+      existing.disconnect()
+    }
+    get().cancelReconnectCountdown()
+    set({ reconnectAttempt: 0, connectionStatus: 'connecting', connectionError: null })
+    get().connect()
+  },
   connect: async () => {
     const token = get().token
     if (!token) return
     const server = get().serverUrl
-    const socket = io(server, { auth: { token } })
+    get().cancelReconnectCountdown()
+    const existingSocket = get().socket
+    if (existingSocket) {
+      if (typeof existingSocket.removeAllListeners === 'function') existingSocket.removeAllListeners()
+      if (existingSocket.io?.off) existingSocket.io.off('close')
+      existingSocket.disconnect()
+    }
+    set({ connectionStatus: 'connecting', connectionError: null })
+    const socket = io(server, { auth: { token }, reconnection: false })
     set({ socket })
+    const manager = socket.io
+    let handleCloseRef = null
+
+    const scheduleReconnect = (error) => {
+      if (!get().token) return
+      const message = typeof error === 'string' ? error : error?.message || null
+      if (manager?.off && handleCloseRef) manager.off('close', handleCloseRef)
+      if (reconnectTimeoutId) {
+        if (message) {
+          set((state) => {
+            if (state.connectionError === message) return state
+            return { connectionError: message }
+          })
+        }
+        return
+      }
+      const nextAttempt = get().reconnectAttempt + 1
+      const delay = RECONNECT_DELAYS[nextAttempt - 1]
+      set((state) => {
+        const patch = { reconnectAttempt: nextAttempt, connectionError: message || null }
+        if (state.socket === socket) patch.socket = null
+        return patch
+      })
+      if (delay) {
+        get().beginReconnectCountdown(delay, message)
+      } else {
+        set((state) => {
+          const patch = {
+            connectionStatus: 'awaiting_manual',
+            retryDelay: null,
+            retryAt: null,
+            retrySecondsRemaining: null,
+          }
+          if (message) patch.connectionError = message
+          if (state.socket === socket) patch.socket = null
+          return patch
+        })
+      }
+    }
+
+    const handleClose = (reason) => {
+      scheduleReconnect(reason)
+    }
+    handleCloseRef = handleClose
+
+    if (manager?.on) manager.on('close', handleClose)
 
     socket.on('connect', async () => {
+      get().cancelReconnectCountdown()
+      set({ connectionStatus: 'connected', reconnectAttempt: 0, connectionError: null })
       socket.emit('init:request', {})
       try {
         const { data } = await axios.get(`${server}/api/users`, { headers: buildAuthHeaders(get().token) })
@@ -549,6 +685,10 @@ const useStore = create((set, get) => ({
         console.error('voice rooms fetch failed', err)
       }
       get().refreshAudioDevices()
+    })
+
+    socket.on('connect_error', (err) => {
+      scheduleReconnect(err)
     })
 
     socket.on('init:response', ({ workspaces, channels, activeChannelId, messages }) => {
@@ -865,7 +1005,7 @@ const useStore = create((set, get) => ({
       }
     })
     socket.on('voice:error', ({ error }) => set({ voiceStatus: error || 'error' }))
-    socket.on('disconnect', () => {
+    socket.on('disconnect', (reason) => {
       const stream = get().voiceStream
       if (stream) stream.getTracks().forEach((track) => track.stop())
       voicePeerConnections.forEach((_, id) => teardownVoicePeer(id, set))
@@ -880,6 +1020,8 @@ const useStore = create((set, get) => ({
         voiceSelfSocketId: null,
         voiceStatus: 'disconnected',
       })
+      if (reason === 'io client disconnect') return
+      scheduleReconnect(reason)
     })
   },
 

--- a/client/src/ui/App.jsx
+++ b/client/src/ui/App.jsx
@@ -60,12 +60,24 @@ export default function App() {
   const connect = useStore((s) => s.connect)
   const view = useStore((s) => s.view)
   const socketConnected = useStore((s) => s.socket?.connected ?? false)
+  const connectionStatus = useStore((s) => s.connectionStatus)
+  const retrySecondsRemaining = useStore((s) => s.retrySecondsRemaining)
+  const retryDelay = useStore((s) => s.retryDelay)
+  const connectionError = useStore((s) => s.connectionError)
+  const triggerReconnectNow = useStore((s) => s.triggerReconnectNow)
   const [showSplash, setShowSplash] = useState(true)
   const [minimumVisible, setMinimumVisible] = useState(false)
 
   useEffect(() => {
     if (token) connect()
   }, [token, connect])
+
+  useEffect(() => {
+    if (!token) return
+    if (!showSplash && ['connecting', 'retrying', 'awaiting_manual'].includes(connectionStatus)) {
+      setShowSplash(true)
+    }
+  }, [token, connectionStatus, showSplash])
 
   useEffect(() => {
     if (!showSplash) return undefined
@@ -80,17 +92,50 @@ export default function App() {
       setShowSplash(false)
       return
     }
-    if (socketConnected) {
+    if (['retrying', 'awaiting_manual', 'connecting'].includes(connectionStatus)) {
+      return
+    }
+    if (socketConnected && connectionStatus === 'connected') {
       const delay = setTimeout(() => setShowSplash(false), 250)
       return () => clearTimeout(delay)
     }
-  }, [minimumVisible, showSplash, token, socketConnected])
+  }, [minimumVisible, showSplash, token, socketConnected, connectionStatus])
 
   const splashSubheading = useMemo(() => {
     if (!token) return 'Подготовка формы входа…'
-    if (!socketConnected) return 'Подключаемся к серверу и загружаем рабочие пространства…'
+    if (connectionStatus === 'retrying') return 'Пытаемся восстановить соединение…'
+    if (connectionStatus === 'awaiting_manual') return 'Соединение потеряно'
+    if (connectionStatus === 'connecting' || !socketConnected)
+      return 'Подключаемся к серверу и загружаем рабочие пространства…'
     return 'Почти готово!'
-  }, [token, socketConnected])
+  }, [token, socketConnected, connectionStatus])
+
+  const countdownSeconds = useMemo(() => {
+    if (typeof retrySecondsRemaining === 'number') return Math.max(0, retrySecondsRemaining)
+    if (typeof retryDelay === 'number') return Math.max(0, Math.ceil(retryDelay / 1000))
+    return null
+  }, [retrySecondsRemaining, retryDelay])
+
+  const splashStatusText = useMemo(() => {
+    if (!token) return null
+    if (connectionStatus === 'retrying') {
+      if (countdownSeconds !== null) {
+        const seconds = Math.max(1, countdownSeconds)
+        return `Нет соединения. Переподключение через ${seconds} сек.`
+      }
+      return 'Нет соединения. Пытаемся переподключиться…'
+    }
+    if (connectionStatus === 'awaiting_manual') {
+      const base = 'Нет соединения. Попробуйте переподключиться вручную.'
+      if (!connectionError) return base
+      const normalizedError = String(connectionError).trim()
+      if (!normalizedError.length) return base
+      return `${base} (${normalizedError})`
+    }
+    return null
+  }, [token, connectionStatus, countdownSeconds, connectionError])
+
+  const manualActionLabel = connectionStatus === 'awaiting_manual' ? 'Подключиться сейчас' : undefined
 
   return (
     <div className="h-full w-full app-bg font-mc">
@@ -98,6 +143,9 @@ export default function App() {
         showSplash={showSplash}
         heading={token ? 'Секунду…' : 'Добро пожаловать'}
         subheading={splashSubheading}
+        statusText={splashStatusText}
+        secondaryActionLabel={manualActionLabel}
+        onSecondaryAction={manualActionLabel ? triggerReconnectNow : undefined}
       />
 
       <div className="h-full w-full overflow-hidden relative">

--- a/client/src/ui/SplashScreen.jsx
+++ b/client/src/ui/SplashScreen.jsx
@@ -44,7 +44,15 @@ const orbTransition = {
   ease: [0.66, 0, 0.34, 1],
 }
 
-export default function SplashScreen({ showSplash, onExitComplete, heading = 'Загрузка', subheading = 'Подготовка данных…' }) {
+export default function SplashScreen({
+  showSplash,
+  onExitComplete,
+  heading = 'Загрузка',
+  subheading = 'Подготовка данных…',
+  statusText = '',
+  secondaryActionLabel,
+  onSecondaryAction,
+}) {
   return (
     <AnimatePresence onExitComplete={onExitComplete}>
       {showSplash && (
@@ -108,11 +116,31 @@ export default function SplashScreen({ showSplash, onExitComplete, heading = 'З
               {subheading}
             </motion.p>
 
+            {statusText ? (
+              <motion.p
+                className="mt-3 text-sm text-center text-white/80 leading-relaxed"
+                animate={{ opacity: [0.45, 0.75, 0.45] }}
+                transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+              >
+                {statusText}
+              </motion.p>
+            ) : null}
+
             <motion.div
               className="splash-progress"
               animate={{ width: ['12%', '68%', '42%', '96%'] }}
               transition={{ duration: 5.4, repeat: Infinity, ease: 'easeInOut' }}
             />
+
+            {secondaryActionLabel && onSecondaryAction ? (
+              <button
+                type="button"
+                className="mt-4 inline-flex items-center justify-center rounded-full bg-white/10 px-5 py-2 text-sm font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/60"
+                onClick={onSecondaryAction}
+              >
+                {secondaryActionLabel}
+              </button>
+            ) : null}
           </motion.div>
         </motion.div>
       )}


### PR DESCRIPTION
## Summary
- add reconnection state, timers, and helper actions to the socket store to schedule 5s/10s/20s retry attempts and surface connection errors
- hook socket connect_error/close/disconnect events to update status, clear timers on success, and expose a manual reconnect trigger for the UI
- show retry status messaging and a manual reconnect button on the splash screen while connections are re-establishing

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68d6ea2d154c8324b8128479fc98077e