### PR TITLE
Add channel and voice avatar management

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "NE-client",
-    "version": "0.3.0",
+    "version": "0.9.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "NE-client",
-            "version": "0.3.0",
+            "version": "0.9.1",
             "dependencies": {
                 "axios": "^1.7.7",
                 "electron-updater": "^6.6.2",

--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -273,6 +273,36 @@ const normalizeChannel = (raw) => {
     createdBy: raw.createdBy ?? raw.created_by ?? '',
     memberCount: raw.memberCount ?? raw.member_count ?? 0,
     membershipRole: raw.membershipRole ?? raw.membership_role ?? '',
+    avatarUrl: raw.avatarUrl ?? raw.avatar_url ?? '',
+    avatarUpdatedAt: raw.avatarUpdatedAt ?? raw.avatar_updated_at ?? 0,
+  }
+}
+
+const normalizeVoiceMember = (raw) => {
+  if (!raw) return null
+  return {
+    userId: raw.userId ?? raw.user_id ?? '',
+    username: raw.username ?? '',
+    role: raw.role ?? 'member',
+    addedAt: raw.addedAt ?? raw.added_at ?? 0,
+  }
+}
+
+const normalizeVoiceRoom = (raw) => {
+  if (!raw) return null
+  const members = Array.isArray(raw.members)
+    ? raw.members.map(normalizeVoiceMember).filter(Boolean)
+    : undefined
+  return {
+    id: raw.id,
+    name: raw.name ?? 'Voice room',
+    createdAt: raw.createdAt ?? raw.created_at ?? 0,
+    createdBy: raw.createdBy ?? raw.created_by ?? '',
+    participantCount: raw.participantCount ?? raw.participant_count ?? 0,
+    membershipRole: raw.membershipRole ?? raw.membership_role ?? '',
+    avatarUrl: raw.avatarUrl ?? raw.avatar_url ?? '',
+    avatarUpdatedAt: raw.avatarUpdatedAt ?? raw.avatar_updated_at ?? 0,
+    members,
   }
 }
 
@@ -418,6 +448,32 @@ const useStore = create((set, get) => ({
       return null
     }
   },
+  buildChannelAvatarUrl: (channel) => {
+    if (!channel?.avatarUrl) return null
+    try {
+      const server = get().serverUrl
+      const base = server.endsWith('/') ? server : `${server}/`
+      const url = new URL(channel.avatarUrl, base)
+      if (channel.avatarUpdatedAt) url.searchParams.set('v', channel.avatarUpdatedAt)
+      return url.toString()
+    } catch (err) {
+      console.error('channel avatar url build failed', err)
+      return null
+    }
+  },
+  buildVoiceRoomAvatarUrl: (room) => {
+    if (!room?.avatarUrl) return null
+    try {
+      const server = get().serverUrl
+      const base = server.endsWith('/') ? server : `${server}/`
+      const url = new URL(room.avatarUrl, base)
+      if (room.avatarUpdatedAt) url.searchParams.set('v', room.avatarUpdatedAt)
+      return url.toString()
+    } catch (err) {
+      console.error('voice avatar url build failed', err)
+      return null
+    }
+  },
   refreshAudioDevices: async () => {
     if (!navigator?.mediaDevices?.enumerateDevices) return
     try {
@@ -502,9 +558,11 @@ const useStore = create((set, get) => ({
       payload,
       { headers: buildAuthHeaders(token) },
     )
-    if (data?.room) {
-      set((state) => ({ voiceRooms: [...state.voiceRooms.filter((room) => room.id !== data.room.id), data.room] }))
+    const room = normalizeVoiceRoom(data?.room)
+    if (room) {
+      set((state) => ({ voiceRooms: [...state.voiceRooms.filter((entry) => entry.id !== room.id), room] }))
     }
+    return room
   },
   updateVoiceRoomMembers: async (roomId, { upserts = [], remove = [] } = {}) => {
     const token = get().token
@@ -514,13 +572,15 @@ const useStore = create((set, get) => ({
       { upserts, remove },
       { headers: buildAuthHeaders(token) },
     )
-    if (data?.room) {
+    const room = normalizeVoiceRoom(data?.room)
+    if (room) {
       set((state) => ({
-        voiceRooms: state.voiceRooms.some((room) => room.id === roomId)
-          ? state.voiceRooms.map((room) => (room.id === roomId ? { ...room, ...data.room } : room))
-          : [...state.voiceRooms, data.room],
+        voiceRooms: state.voiceRooms.some((entry) => entry.id === roomId)
+          ? state.voiceRooms.map((entry) => (entry.id === roomId ? { ...entry, ...room } : entry))
+          : [...state.voiceRooms, room],
       }))
     }
+    return room
   },
   deleteVoiceRoom: async (roomId) => {
     const token = get().token
@@ -531,6 +591,42 @@ const useStore = create((set, get) => ({
       voiceParticipants: { ...state.voiceParticipants, [roomId]: [] },
     }))
     if (get().activeVoiceRoomId === roomId) get().leaveVoiceRoom(false)
+  },
+  uploadVoiceRoomAvatar: async (roomId, file) => {
+    const token = get().token
+    if (!token) throw new Error('not_authenticated')
+    if (!roomId || !file) throw new Error('invalid_payload')
+    const form = new FormData()
+    form.append('avatar', file)
+    const { data } = await axios.post(`${get().serverUrl}/api/voice-rooms/${roomId}/avatar`, form, {
+      headers: buildAuthHeaders(token),
+    })
+    const room = normalizeVoiceRoom(data?.room)
+    if (room) {
+      set((state) => ({
+        voiceRooms: state.voiceRooms.some((entry) => entry.id === room.id)
+          ? state.voiceRooms.map((entry) => (entry.id === room.id ? { ...entry, ...room } : entry))
+          : [...state.voiceRooms, room],
+      }))
+    }
+    return room
+  },
+  deleteVoiceRoomAvatar: async (roomId) => {
+    const token = get().token
+    if (!token) throw new Error('not_authenticated')
+    if (!roomId) throw new Error('invalid_room')
+    const { data } = await axios.delete(`${get().serverUrl}/api/voice-rooms/${roomId}/avatar`, {
+      headers: buildAuthHeaders(token),
+    })
+    const room = normalizeVoiceRoom(data?.room)
+    if (room) {
+      set((state) => ({
+        voiceRooms: state.voiceRooms.some((entry) => entry.id === room.id)
+          ? state.voiceRooms.map((entry) => (entry.id === room.id ? { ...entry, ...room } : entry))
+          : [...state.voiceRooms, room],
+      }))
+    }
+    return room
   },
 
   cancelReconnectCountdown: () => {
@@ -680,7 +776,7 @@ const useStore = create((set, get) => ({
       }
       try {
         const { data: voiceData } = await axios.get(`${server}/api/voice-rooms`, { headers: buildAuthHeaders(get().token) })
-        set({ voiceRooms: (voiceData.rooms || []).map((room) => ({ ...room })) })
+        set({ voiceRooms: (voiceData.rooms || []).map(normalizeVoiceRoom).filter(Boolean) })
       } catch (err) {
         console.error('voice rooms fetch failed', err)
       }
@@ -904,7 +1000,7 @@ const useStore = create((set, get) => ({
 
     socket.on('presence:update', ({ onlineUserIds }) => set({ onlineUserIds }))
     socket.on('voice:rooms:update', ({ rooms }) => {
-      if (Array.isArray(rooms)) set({ voiceRooms: rooms.map((room) => ({ ...room })) })
+      if (Array.isArray(rooms)) set({ voiceRooms: rooms.map(normalizeVoiceRoom).filter(Boolean) })
     })
     socket.on('voice:state', ({ roomId, participants }) => {
       if (!roomId) return
@@ -1119,6 +1215,42 @@ const useStore = create((set, get) => ({
       : []
     if (channel && members.length) {
       set((state) => ({ channelMembers: { ...state.channelMembers, [channel.id]: members } }))
+    }
+    return channel
+  },
+  uploadChannelAvatar: async (channelId, file) => {
+    const token = get().token
+    if (!token) throw new Error('not_authenticated')
+    if (!channelId || !file) throw new Error('invalid_payload')
+    const form = new FormData()
+    form.append('avatar', file)
+    const { data } = await axios.post(`${get().serverUrl}/api/channels/${channelId}/avatar`, form, {
+      headers: buildAuthHeaders(token),
+    })
+    const channel = normalizeChannel(data?.channel)
+    if (channel) {
+      set((state) => ({
+        channels: state.channels.some((entry) => entry.id === channel.id)
+          ? state.channels.map((entry) => (entry.id === channel.id ? { ...entry, ...channel } : entry))
+          : [...state.channels, channel],
+      }))
+    }
+    return channel
+  },
+  deleteChannelAvatar: async (channelId) => {
+    const token = get().token
+    if (!token) throw new Error('not_authenticated')
+    if (!channelId) throw new Error('invalid_channel')
+    const { data } = await axios.delete(`${get().serverUrl}/api/channels/${channelId}/avatar`, {
+      headers: buildAuthHeaders(token),
+    })
+    const channel = normalizeChannel(data?.channel)
+    if (channel) {
+      set((state) => ({
+        channels: state.channels.some((entry) => entry.id === channel.id)
+          ? state.channels.map((entry) => (entry.id === channel.id ? { ...entry, ...channel } : entry))
+          : [...state.channels, channel],
+      }))
     }
     return channel
   },

--- a/client/src/ui/Sidebar.jsx
+++ b/client/src/ui/Sidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import useStore, { buildDirectChannelId } from '../state/store.js'
 import AvatarImage from './AvatarImage.jsx'
 
@@ -20,6 +20,7 @@ export default function Sidebar() {
   const openDirectChat = useStore((s) => s.openDirectChat)
   const directPeers = useStore((s) => s.directPeers)
   const buildAvatarUrl = useStore((s) => s.buildAvatarUrl)
+  const buildChannelAvatarUrl = useStore((s) => s.buildChannelAvatarUrl)
   const voiceRooms = useStore((s) => s.voiceRooms)
   const activeVoiceRoomId = useStore((s) => s.activeVoiceRoomId)
   const voiceParticipants = useStore((s) => s.voiceParticipants)
@@ -27,6 +28,10 @@ export default function Sidebar() {
   const leaveVoiceRoom = useStore((s) => s.leaveVoiceRoom)
   const createVoiceRoom = useStore((s) => s.createVoiceRoom)
   const deleteVoiceRoom = useStore((s) => s.deleteVoiceRoom)
+  const uploadChannelAvatar = useStore((s) => s.uploadChannelAvatar)
+  const uploadVoiceRoomAvatar = useStore((s) => s.uploadVoiceRoomAvatar)
+  const deleteVoiceRoomAvatar = useStore((s) => s.deleteVoiceRoomAvatar)
+  const buildVoiceRoomAvatarUrl = useStore((s) => s.buildVoiceRoomAvatarUrl)
   const voiceStatus = useStore((s) => s.voiceStatus)
   const createPrivateChannel = useStore((s) => s.createPrivateChannel)
   const voicePeerStates = useStore((s) => s.voicePeerStates)
@@ -75,14 +80,51 @@ export default function Sidebar() {
   const [showPrivate, setShowPrivate] = useState(true)
   const [showUsers, setShowUsers] = useState(true)
   const [showVoice, setShowVoice] = useState(true)
+  const [channelAvatarFile, setChannelAvatarFile] = useState(null)
+  const [channelAvatarPreview, setChannelAvatarPreview] = useState('')
+  const [channelAvatarError, setChannelAvatarError] = useState(null)
+  const [voiceAvatarFile, setVoiceAvatarFile] = useState(null)
+  const [voiceAvatarPreview, setVoiceAvatarPreview] = useState('')
+  const [voiceAvatarError, setVoiceAvatarError] = useState(null)
+  const [voiceAvatarRemove, setVoiceAvatarRemove] = useState(false)
 
   const editingCount =
     editingRoom?.participantCount ??
     (editingRoom ? voiceParticipantsCount(editingRoom.id) : undefined)
   const editingActive = editingRoom ? activeVoiceRoomId === editingRoom.id : false
 
+  useEffect(() => () => {
+    if (channelAvatarPreview && channelAvatarPreview.startsWith('blob:')) {
+      URL.revokeObjectURL(channelAvatarPreview)
+    }
+  }, [channelAvatarPreview])
+
+  useEffect(() => () => {
+    if (voiceAvatarPreview && voiceAvatarPreview.startsWith('blob:')) {
+      URL.revokeObjectURL(voiceAvatarPreview)
+    }
+  }, [voiceAvatarPreview])
+
   const toggleSelection = (userId) => {
     setSelectedIds((current) => (current.includes(userId) ? current.filter((id) => id !== userId) : [...current, userId]))
+  }
+
+  const handleChannelAvatarChange = (event) => {
+    const file = event.target.files?.[0]
+    setChannelAvatarError(null)
+    if (file) {
+      setChannelAvatarFile(file)
+      setChannelAvatarPreview(URL.createObjectURL(file))
+    } else {
+      setChannelAvatarFile(null)
+      setChannelAvatarPreview('')
+    }
+  }
+
+  const clearChannelAvatarSelection = () => {
+    setChannelAvatarFile(null)
+    setChannelAvatarPreview('')
+    setChannelAvatarError(null)
   }
 
   const closeCreateDialog = () => {
@@ -91,6 +133,7 @@ export default function Sidebar() {
     setChannelName('')
     setSelectedIds([])
     setCreateError(null)
+    clearChannelAvatarSelection()
   }
 
   const handleCreatePrivateChannel = async () => {
@@ -103,6 +146,16 @@ export default function Sidebar() {
     setCreateError(null)
     try {
       const channel = await createPrivateChannel(channelName, selectedIds)
+      if (channel?.id && channelAvatarFile) {
+        try {
+          await uploadChannelAvatar(channel.id, channelAvatarFile)
+        } catch (err) {
+          console.error('channel avatar upload failed', err)
+          setCreateError('Не удалось загрузить аватар канала')
+          setCreating(false)
+          return
+        }
+      }
       if (channel?.id) switchChannel(channel.id)
       closeCreateDialog()
     } catch (err) {
@@ -120,6 +173,8 @@ export default function Sidebar() {
     setVoiceModeratorIds([])
     setVoiceError(null)
     setEditingRoom(null)
+    clearVoiceAvatarSelection()
+    setVoiceAvatarRemove(false)
   }
 
   const closeVoiceDialog = () => {
@@ -130,6 +185,33 @@ export default function Sidebar() {
   const toggleVoiceSelection = (userId) => {
     setVoiceSelectedIds((current) => (current.includes(userId) ? current.filter((id) => id !== userId) : [...current, userId]))
     setVoiceModeratorIds((current) => (current.includes(userId) ? current.filter((id) => id !== userId) : current))
+  }
+
+  const handleVoiceAvatarChange = (event) => {
+    const file = event.target.files?.[0]
+    setVoiceAvatarError(null)
+    if (file) {
+      setVoiceAvatarFile(file)
+      setVoiceAvatarPreview(URL.createObjectURL(file))
+      setVoiceAvatarRemove(false)
+    } else {
+      setVoiceAvatarFile(null)
+      setVoiceAvatarPreview('')
+    }
+  }
+
+  const clearVoiceAvatarSelection = () => {
+    setVoiceAvatarFile(null)
+    setVoiceAvatarPreview('')
+    setVoiceAvatarError(null)
+    setVoiceAvatarRemove(false)
+  }
+
+  const markVoiceAvatarRemoval = () => {
+    setVoiceAvatarFile(null)
+    setVoiceAvatarPreview('')
+    setVoiceAvatarRemove(true)
+    setVoiceAvatarError(null)
   }
 
   const toggleVoiceModerator = (userId) => {
@@ -144,7 +226,9 @@ export default function Sidebar() {
     }
     setVoiceSaving(true)
     setVoiceError(null)
+    setVoiceAvatarError(null)
     try {
+      let targetRoom = editingRoom || null
       if (editingRoom) {
         const baseMembers = (editingRoom.members || []).filter((m) => m.userId !== editingRoom.createdBy)
         const selectedSet = new Set(voiceSelectedIds)
@@ -156,9 +240,39 @@ export default function Sidebar() {
           return { userId, role }
         })
         const filtered = upserts.filter(Boolean)
-        await updateVoiceRoomMembers(editingRoom.id, { upserts: filtered, remove })
+        const updated = await updateVoiceRoomMembers(editingRoom.id, { upserts: filtered, remove })
+        if (updated) {
+          targetRoom = updated
+        }
       } else {
-        await createVoiceRoom(voiceName, { members: voiceSelectedIds, admins: voiceModeratorIds })
+        const created = await createVoiceRoom(voiceName, { members: voiceSelectedIds, admins: voiceModeratorIds })
+        if (created) {
+          targetRoom = created
+          setEditingRoom(created)
+          const members = created.members || []
+          setVoiceSelectedIds(members.map((m) => m.userId).filter((id) => id !== created.createdBy))
+          setVoiceModeratorIds(members.filter((m) => m.role === 'admin').map((m) => m.userId))
+        }
+      }
+      if (targetRoom?.id) {
+        if (voiceAvatarRemove) {
+          try {
+            await deleteVoiceRoomAvatar(targetRoom.id)
+          } catch (err) {
+            console.error('voice room avatar delete failed', err)
+            setVoiceAvatarError('Не удалось удалить аватар')
+            return
+          }
+        }
+        if (voiceAvatarFile) {
+          try {
+            await uploadVoiceRoomAvatar(targetRoom.id, voiceAvatarFile)
+          } catch (err) {
+            console.error('voice room avatar upload failed', err)
+            setVoiceAvatarError('Не удалось загрузить аватар')
+            return
+          }
+        }
       }
       resetVoiceDialog()
     } catch (err) {
@@ -230,6 +344,7 @@ export default function Sidebar() {
               filteredPublicChannels.map((channel) => {
                 const active = channel.id === activeChannelId
                 const unreadCount = unread[channel.id] || 0
+                const avatarSrc = buildChannelAvatarUrl?.(channel)
                 return (
                   <button
                     key={channel.id}
@@ -238,7 +353,11 @@ export default function Sidebar() {
                     className={`w-full flex items-center justify-between px-3 py-3 rounded-2xl transition-colors ${active ? 'panel' : 'glass hover:bg-white/10'}`}
                   >
                     <div className="flex items-center gap-3">
-                      <div className="avatar">#{channel.name.slice(0, 2).toUpperCase()}</div>
+                      <AvatarImage
+                        user={{ username: channel.name }}
+                        src={avatarSrc}
+                        fallback={channel.name}
+                      />
                       <div>
                         <div className="text-sm font-medium">#{channel.name}</div>
                         <div className="text-xs text-white/60">Общий канал</div>
@@ -270,7 +389,11 @@ export default function Sidebar() {
               <span className="text-white/30 text-[11px]">{filteredPrivateChannels.length}</span>
               <button
                 type="button"
-                onClick={() => setCreateDialogOpen(true)}
+                onClick={() => {
+                  setCreateError(null)
+                  clearChannelAvatarSelection()
+                  setCreateDialogOpen(true)
+                }}
                 className="text-white/40 hover:text-white/80 transition text-lg leading-none"
                 title="Создать приватный канал"
               >
@@ -289,6 +412,7 @@ export default function Sidebar() {
                     : channel.membershipRole === 'admin'
                       ? 'Админ'
                       : 'Участник'
+                const avatarSrc = buildChannelAvatarUrl?.(channel)
                 return (
                   <button
                     key={channel.id}
@@ -297,11 +421,15 @@ export default function Sidebar() {
                     className={`w-full flex items-center justify-between px-3 py-3 rounded-2xl transition-colors ${active ? 'panel' : 'glass hover:bg-white/10'}`}
                   >
                     <div className="flex items-center gap-3">
-                      <div className="avatar">🔒</div>
+                      <AvatarImage
+                        user={{ username: channel.name }}
+                        src={avatarSrc}
+                        fallback={channel.name}
+                      />
                       <div>
                         <div className="text-sm font-medium">{channel.name}</div>
                         <div className="text-xs text-white/60 flex items-center gap-2">
-                          <span>{role}</span>
+                          <span>🔒 {role}</span>
                           <span>•</span>
                           <span>{channel.memberCount} участн.</span>
                         </div>
@@ -390,6 +518,8 @@ export default function Sidebar() {
                 setVoiceSelectedIds([])
                 setVoiceModeratorIds([])
                 setVoiceError(null)
+                clearVoiceAvatarSelection()
+                setVoiceAvatarRemove(false)
                 setVoiceDialogOpen(true)
               }}
               className="text-white/40 hover:text-white/80 transition text-lg leading-none"
@@ -407,23 +537,28 @@ export default function Sidebar() {
                 return (
                   <div key={room.id} className={`rounded-2xl border border-white/10 px-4 py-3 space-y-3 ${active ? 'panel' : 'glass hover:bg-white/10 transition'}`}>
                     <div className="flex items-center justify-between gap-3">
-                      <div>
-                        <div className="text-sm font-medium flex items-center gap-2">
-                          <span role="img" aria-label="voice">🎙️</span>
-                          {room.name}
+                      <div className="flex items-center gap-3">
+                        <AvatarImage
+                          user={{ username: room.name }}
+                          src={buildVoiceRoomAvatarUrl?.(room)}
+                          fallback={room.name}
+                          size={40}
+                        />
+                        <div>
+                          <div className="text-sm font-medium">{room.name}</div>
+                          <div className="text-xs text-white/50">В голосе: {count}</div>
+                          {active && voiceStatus && (
+                            <div className="text-[11px] text-white/40">
+                              {voiceStatus === 'connecting'
+                                ? 'Подключение...'
+                                : voiceStatus === 'error'
+                                ? 'Ошибка соединения'
+                                : voiceStatus === 'room_closed'
+                                ? 'Комната закрыта'
+                                : 'Подключено'}
+                            </div>
+                          )}
                         </div>
-                        <div className="text-xs text-white/50">В голосе: {count}</div>
-                        {active && voiceStatus && (
-                          <div className="text-[11px] text-white/40">
-                            {voiceStatus === 'connecting'
-                              ? 'Подключение...'
-                              : voiceStatus === 'error'
-                              ? 'Ошибка соединения'
-                              : voiceStatus === 'room_closed'
-                              ? 'Комната закрыта'
-                              : 'Подключено'}
-                          </div>
-                        )}
                       </div>
                       <button
                         type="button"
@@ -475,11 +610,15 @@ export default function Sidebar() {
                           type="button"
                           onClick={() => {
                             setEditingRoom(room)
-                            setVoiceDialogOpen(true)
                             setVoiceName(room.name)
                             const members = room.members || []
                             setVoiceSelectedIds(members.map((m) => m.userId).filter((id) => id !== room.createdBy))
                             setVoiceModeratorIds(members.filter((m) => m.role === 'admin').map((m) => m.userId))
+                            setVoiceAvatarFile(null)
+                            setVoiceAvatarPreview(buildVoiceRoomAvatarUrl?.(room) || '')
+                            setVoiceAvatarRemove(false)
+                            setVoiceAvatarError(null)
+                            setVoiceDialogOpen(true)
                           }}
                           className="text-white/50 hover:text-white/80 transition"
                         >
@@ -557,6 +696,29 @@ export default function Sidebar() {
                   {otherUsers.length === 0 && <div className="text-sm text-white/40">Больше нет пользователей</div>}
                 </div>
               </div>
+              <div className="space-y-2">
+                <div className="text-xs uppercase tracking-[0.2em] text-white/40">Аватар</div>
+                <div className="flex items-center gap-3">
+                  <AvatarImage
+                    user={{ username: channelName || 'channel' }}
+                    size={48}
+                    src={channelAvatarPreview || undefined}
+                    fallback={channelName || 'Канал'}
+                  />
+                  <div className="flex flex-col gap-2 text-xs">
+                    <label className="cursor-pointer px-3 py-1.5 rounded-2xl bg-white/10 hover:bg-white/20 transition">
+                      Выбрать файл
+                      <input type="file" accept="image/*" className="hidden" onChange={handleChannelAvatarChange} disabled={creating} />
+                    </label>
+                    {channelAvatarPreview && (
+                      <button type="button" onClick={clearChannelAvatarSelection} className="text-white/50 hover:text-white/80 transition" disabled={creating}>
+                        Очистить
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {channelAvatarError && <div className="text-xs text-red-300">{channelAvatarError}</div>}
+              </div>
             </div>
             <div className="px-5 py-4 border-t border-white/10 flex items-center justify-end gap-3">
               <button
@@ -623,20 +785,20 @@ export default function Sidebar() {
               {editingRoom && (
                 <div className="space-y-2">
                   <div className="text-xs uppercase tracking-[0.2em] text-white/40">Создатель</div>
-                  <div className="flex items-center gap-3 bg-white/5 rounded-2xl px-3 py-2">
-                    <AvatarImage user={users.find((u) => u.id === editingRoom.createdBy)} size={28} src={buildAvatarUrl?.(users.find((u) => u.id === editingRoom.createdBy))} />
-                    <div className="text-sm text-white/80">
-                      @{users.find((u) => u.id === editingRoom.createdBy)?.username || editingRoom.createdBy}
-                    </div>
+                <div className="flex items-center gap-3 bg-white/5 rounded-2xl px-3 py-2">
+                  <AvatarImage user={users.find((u) => u.id === editingRoom.createdBy)} size={28} src={buildAvatarUrl?.(users.find((u) => u.id === editingRoom.createdBy))} />
+                  <div className="text-sm text-white/80">
+                    @{users.find((u) => u.id === editingRoom.createdBy)?.username || editingRoom.createdBy}
+                  </div>
 
-                    <span className="text-[11px] text-white/40">Создатель</span>
+                  <span className="text-[11px] text-white/40">Создатель</span>
 
-                    <div className="text-xs text-white/50">В голосе: {editingCount ?? 0}</div>
-                    {editingActive && voiceStatus && (
-                      <div className="text-[11px] text-white/40">
-                        {voiceStatus === 'connecting'
-                          ? 'Подключение...'
-                          : voiceStatus === 'error'
+                  <div className="text-xs text-white/50">В голосе: {editingCount ?? 0}</div>
+                  {editingActive && voiceStatus && (
+                    <div className="text-[11px] text-white/40">
+                      {voiceStatus === 'connecting'
+                        ? 'Подключение...'
+                        : voiceStatus === 'error'
                           ? 'Ошибка соединения'
                           : voiceStatus === 'room_closed'
                           ? 'Комната закрыта'
@@ -646,6 +808,47 @@ export default function Sidebar() {
                   </div>
                 </div>
               )}
+              <div className="space-y-2">
+                <div className="text-xs uppercase tracking-[0.2em] text-white/40">Аватар</div>
+                <div className="flex items-center gap-3">
+                  <AvatarImage
+                    user={{ username: editingRoom?.name || voiceName || 'voice' }}
+                    size={48}
+                    src={voiceAvatarPreview || undefined}
+                    fallback={editingRoom?.name || voiceName || 'Комната'}
+                  />
+                  <div className="flex flex-col gap-2 text-xs">
+                    <label className="cursor-pointer px-3 py-1.5 rounded-2xl bg-white/10 hover:bg-white/20 transition">
+                      Выбрать файл
+                      <input type="file" accept="image/*" className="hidden" onChange={handleVoiceAvatarChange} disabled={voiceSaving} />
+                    </label>
+                    {(voiceAvatarPreview || voiceAvatarFile) && (
+                      <button
+                        type="button"
+                        onClick={clearVoiceAvatarSelection}
+                        className="text-white/50 hover:text-white/80 transition"
+                        disabled={voiceSaving}
+                      >
+                        Сбросить
+                      </button>
+                    )}
+                    {editingRoom?.avatarUrl && !voiceAvatarFile && !voiceAvatarRemove && (
+                      <button
+                        type="button"
+                        onClick={markVoiceAvatarRemoval}
+                        className="text-white/50 hover:text-white/80 transition"
+                        disabled={voiceSaving}
+                      >
+                        Удалить текущий
+                      </button>
+                    )}
+                    {voiceAvatarRemove && !voiceAvatarFile && (
+                      <div className="text-[11px] text-white/50">Аватар будет удалён</div>
+                    )}
+                  </div>
+                </div>
+                {voiceAvatarError && <div className="text-xs text-red-300">{voiceAvatarError}</div>}
+              </div>
               <div className="space-y-3">
                 <div className="text-xs uppercase tracking-[0.2em] text-white/40">Участники</div>
                 <div className="space-y-2 max-h-64 overflow-y-auto pr-1">

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -155,10 +155,15 @@ const PORT = process.env.PORT || 4000
 const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret'
 const UPLOAD_DIR = process.env.UPLOAD_DIR || 'uploads'
 const AVATAR_DIR = path.join(UPLOAD_DIR, 'avatars')
+const CHANNEL_AVATAR_DIR = path.join(AVATAR_DIR, 'channels')
+const VOICE_AVATAR_DIR = path.join(AVATAR_DIR, 'voice-rooms')
 
 if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR, { recursive: true })
 if (!fs.existsSync(path.join(UPLOAD_DIR, 'tmp'))) fs.mkdirSync(path.join(UPLOAD_DIR, 'tmp'), { recursive: true })
 if (!fs.existsSync(AVATAR_DIR)) fs.mkdirSync(AVATAR_DIR, { recursive: true })
+if (!fs.existsSync(CHANNEL_AVATAR_DIR)) fs.mkdirSync(CHANNEL_AVATAR_DIR, { recursive: true })
+if (!fs.existsSync(VOICE_AVATAR_DIR)) fs.mkdirSync(VOICE_AVATAR_DIR, { recursive: true })
+const UPLOADS_ROOT = path.resolve(UPLOAD_DIR)
 
 const db = new Database('messenger_v4.db')
 db.pragma('journal_mode = WAL')
@@ -217,7 +222,10 @@ CREATE TABLE IF NOT EXISTS channels (
   name TEXT NOT NULL,
   created_at INTEGER NOT NULL,
   is_private INTEGER NOT NULL DEFAULT 0,
-  created_by TEXT DEFAULT ''
+  created_by TEXT DEFAULT '',
+  avatar_url TEXT DEFAULT '',
+  avatar_updated_at INTEGER DEFAULT 0,
+  avatar_mime TEXT DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS messages (
   id TEXT PRIMARY KEY,
@@ -246,7 +254,10 @@ CREATE TABLE IF NOT EXISTS voice_rooms (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
   created_at INTEGER NOT NULL,
-  created_by TEXT NOT NULL
+  created_by TEXT NOT NULL,
+  avatar_url TEXT DEFAULT '',
+  avatar_updated_at INTEGER DEFAULT 0,
+  avatar_mime TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS voice_room_members (
@@ -290,6 +301,12 @@ ensureColumn('invites', 'used_at', 'INTEGER')
 ensureColumn('invites', 'revoked_at', 'INTEGER')
 ensureColumn('channels', 'is_private', 'INTEGER NOT NULL DEFAULT 0')
 ensureColumn('channels', 'created_by', 'TEXT DEFAULT ""')
+ensureColumn('channels', 'avatar_url', 'TEXT DEFAULT ""')
+ensureColumn('channels', 'avatar_updated_at', 'INTEGER DEFAULT 0')
+ensureColumn('channels', 'avatar_mime', 'TEXT DEFAULT ""')
+ensureColumn('voice_rooms', 'avatar_url', 'TEXT DEFAULT ""')
+ensureColumn('voice_rooms', 'avatar_updated_at', 'INTEGER DEFAULT 0')
+ensureColumn('voice_rooms', 'avatar_mime', 'TEXT DEFAULT ""')
 ensureColumn('messages', 'updated_at', 'INTEGER DEFAULT 0')
 
 const hasMessageUpdatedAtColumn = tableHasColumn('messages', 'updated_at')
@@ -334,6 +351,24 @@ try {
   db.prepare('ALTER TABLE channels ADD COLUMN created_by TEXT DEFAULT ""').run()
 } catch (err) {}
 try {
+  db.prepare('ALTER TABLE channels ADD COLUMN avatar_url TEXT DEFAULT ""').run()
+} catch (err) {}
+try {
+  db.prepare('ALTER TABLE channels ADD COLUMN avatar_updated_at INTEGER DEFAULT 0').run()
+} catch (err) {}
+try {
+  db.prepare('ALTER TABLE channels ADD COLUMN avatar_mime TEXT DEFAULT ""').run()
+} catch (err) {}
+try {
+  db.prepare('ALTER TABLE voice_rooms ADD COLUMN avatar_url TEXT DEFAULT ""').run()
+} catch (err) {}
+try {
+  db.prepare('ALTER TABLE voice_rooms ADD COLUMN avatar_updated_at INTEGER DEFAULT 0').run()
+} catch (err) {}
+try {
+  db.prepare('ALTER TABLE voice_rooms ADD COLUMN avatar_mime TEXT DEFAULT ""').run()
+} catch (err) {}
+try {
   db.prepare('ALTER TABLE messages ADD COLUMN updated_at INTEGER DEFAULT 0').run()
 } catch (err) {}
 
@@ -345,9 +380,11 @@ const updateAvatarInfoStmt = db.prepare('UPDATE users SET avatar_url=?, avatar_u
 const updatePasswordStmt = db.prepare('UPDATE users SET password_hash=? WHERE id=?')
 const updateUserRoleStmt = db.prepare('UPDATE users SET role=? WHERE id=?')
 const countAdminsStmt = db.prepare("SELECT COUNT(*) as count FROM users WHERE role='admin'")
-const listVoiceRoomsStmt = db.prepare('SELECT id, name, created_at, created_by FROM voice_rooms ORDER BY created_at ASC')
+const listVoiceRoomsStmt = db.prepare(
+  'SELECT id, name, created_at, created_by, avatar_url, avatar_updated_at, avatar_mime FROM voice_rooms ORDER BY created_at ASC',
+)
 const listVoiceRoomsForUserStmt = db.prepare(
-  `SELECT vr.id, vr.name, vr.created_at, vr.created_by, vrm.role AS membership_role
+  `SELECT vr.id, vr.name, vr.created_at, vr.created_by, vr.avatar_url, vr.avatar_updated_at, vr.avatar_mime, vrm.role AS membership_role
    FROM voice_rooms vr
    LEFT JOIN voice_room_members vrm ON vrm.room_id = vr.id AND vrm.user_id = ?
    WHERE vr.created_by = ? OR vrm.user_id = ?
@@ -356,7 +393,9 @@ const listVoiceRoomsForUserStmt = db.prepare(
 const insertVoiceRoomStmt = db.prepare('INSERT INTO voice_rooms (id, name, created_at, created_by) VALUES (?,?,?,?)')
 const deleteVoiceRoomStmt = db.prepare('DELETE FROM voice_rooms WHERE id=?')
 
-const selectVoiceRoomStmt = db.prepare('SELECT id, name, created_at, created_by FROM voice_rooms WHERE id=?')
+const selectVoiceRoomStmt = db.prepare(
+  'SELECT id, name, created_at, created_by, avatar_url, avatar_updated_at, avatar_mime FROM voice_rooms WHERE id=?',
+)
 const insertVoiceRoomMemberStmt = db.prepare(
   'INSERT OR REPLACE INTO voice_room_members (room_id, user_id, role, added_at, added_by) VALUES (?,?,?,?,?)'
 )
@@ -389,6 +428,9 @@ const selectChannelByIdStmt = db.prepare('SELECT * FROM channels WHERE id=?')
 const insertChannelStmt = db.prepare(
   'INSERT INTO channels (id, workspace_id, name, created_at, is_private, created_by) VALUES (?,?,?,?,?,?)',
 )
+const updateChannelAvatarStmt = db.prepare(
+  'UPDATE channels SET avatar_url=?, avatar_updated_at=?, avatar_mime=? WHERE id=?',
+)
 const listAllChannelsStmt = db.prepare('SELECT * FROM channels WHERE workspace_id=? ORDER BY created_at ASC')
 const listUserChannelMembershipsStmt = db.prepare('SELECT channel_id, role FROM channel_members WHERE user_id=?')
 const listChannelMembersStmt = db.prepare('SELECT user_id, role FROM channel_members WHERE channel_id=? ORDER BY user_id ASC')
@@ -403,6 +445,9 @@ const deleteChannelStmt = db.prepare('DELETE FROM channels WHERE id=?')
 const findChannelMemberStmt = db.prepare('SELECT role FROM channel_members WHERE channel_id=? AND user_id=?')
 const countChannelMembersStmt = db.prepare('SELECT COUNT(*) as count FROM channel_members WHERE channel_id=?')
 const listAdminsStmt = db.prepare("SELECT id FROM users WHERE role='admin'")
+const updateVoiceRoomAvatarStmt = db.prepare(
+  'UPDATE voice_rooms SET avatar_url=?, avatar_updated_at=?, avatar_mime=? WHERE id=?',
+)
 
 const decryptMessageRow = (row) => {
   if (!row) return row
@@ -468,6 +513,8 @@ const listWorkspaceMembersStmt = db.prepare('SELECT user_id FROM workspace_membe
 
 const normalizeChannelRow = (row) => {
   if (!row) return null
+  const avatarPath = row.avatar_url ?? row.avatarUrl ?? ''
+  const avatarUpdatedAt = row.avatar_updated_at ?? row.avatarUpdatedAt ?? 0
   return {
     id: row.id,
     workspaceId: row.workspace_id,
@@ -475,6 +522,8 @@ const normalizeChannelRow = (row) => {
     createdAt: row.created_at,
     isPrivate: Boolean(row.is_private),
     createdBy: row.created_by || '',
+    avatarUrl: avatarPath ? `/api/channels/${row.id}/avatar` : '',
+    avatarUpdatedAt,
   }
 }
 
@@ -485,6 +534,30 @@ const getChannelMemberCount = (channelId) => {
   } catch (err) {
     warn('[CHANNELS] count members failed', err.message)
     return 0
+  }
+}
+
+const publicChannel = (channel, extras = {}) => {
+  if (!channel) return null
+  const normalized = typeof channel.workspaceId !== 'undefined' ? channel : normalizeChannelRow(channel)
+  if (!normalized) return null
+  const memberCount =
+    typeof extras.memberCount === 'number'
+      ? extras.memberCount
+      : normalized.isPrivate
+        ? getChannelMemberCount(normalized.id)
+        : 0
+  const membershipRole = extras.membershipRole || ''
+  return {
+    id: normalized.id,
+    name: normalized.name,
+    createdAt: normalized.createdAt,
+    isPrivate: normalized.isPrivate,
+    createdBy: normalized.createdBy,
+    memberCount,
+    membershipRole,
+    avatarUrl: normalized.avatarUrl,
+    avatarUpdatedAt: normalized.avatarUpdatedAt,
   }
 }
 
@@ -499,27 +572,20 @@ const getAccessibleChannelsForUser = (user) => {
   }
   const allChannels = listAllChannelsStmt.all(defaultWs.id)
   return allChannels
-    .map(normalizeChannelRow)
-    .filter(Boolean)
-    .filter((channel) => {
-      if (!channel.isPrivate) return true
+    .map((row) => ({ row, normalized: normalizeChannelRow(row) }))
+    .filter(({ normalized }) => Boolean(normalized))
+    .filter(({ normalized }) => {
+      if (!normalized.isPrivate) return true
       if (user.role === 'admin') return true
-      if (channel.createdBy && channel.createdBy === user.id) return true
-      return memberships.has(channel.id)
+      if (normalized.createdBy && normalized.createdBy === user.id) return true
+      return memberships.has(normalized.id)
     })
-    .map((channel) => {
-      const memberCount = channel.isPrivate ? getChannelMemberCount(channel.id) : 0
-      const ownerRole = channel.createdBy && channel.createdBy === user.id ? 'owner' : ''
-      const membershipRole = ownerRole || memberships.get(channel.id) || (user.role === 'admin' && channel.isPrivate ? 'admin' : '')
-      return {
-        id: channel.id,
-        name: channel.name,
-        createdAt: channel.createdAt,
-        isPrivate: channel.isPrivate,
-        createdBy: channel.createdBy,
-        memberCount,
-        membershipRole,
-      }
+    .map(({ normalized }) => {
+      const memberCount = normalized.isPrivate ? getChannelMemberCount(normalized.id) : 0
+      const ownerRole = normalized.createdBy && normalized.createdBy === user.id ? 'owner' : ''
+      const membershipRole =
+        ownerRole || memberships.get(normalized.id) || (user.role === 'admin' && normalized.isPrivate ? 'admin' : '')
+      return publicChannel(normalized, { memberCount, membershipRole })
     })
 }
 
@@ -848,15 +914,12 @@ app.post('/api/channels', auth, (req, res) => {
   const audience = getChannelAudienceUserIds(channelRow)
   emitChannelListForUsers(audience)
   const creatorChannels = getAccessibleChannelsForUser(selectUserById.get(req.user.id)).filter((ch) => ch.id === channelId)
-  const channelPayload = creatorChannels[0] || {
-    id: channelRow.id,
-    name: channelRow.name,
-    createdAt: channelRow.created_at,
-    isPrivate: Boolean(channelRow.is_private),
-    createdBy: channelRow.created_by || req.user.id,
-    memberCount: channelRow.is_private ? getChannelMemberCount(channelRow.id) : 0,
-    membershipRole: privateFlag ? 'owner' : '',
-  }
+  const channelPayload =
+    creatorChannels[0] ||
+    publicChannel(channelRow, {
+      memberCount: channelRow.is_private ? getChannelMemberCount(channelRow.id) : 0,
+      membershipRole: privateFlag ? 'owner' : '',
+    })
   const members = privateFlag ? getChannelMembersDetailed(channelId) : []
   log('[CHANNELS] create', channelId, 'user=' + req.user.id, 'private=' + privateFlag)
   res.status(201).json({ channel: channelPayload, members })
@@ -936,6 +999,16 @@ app.delete('/api/channels/:id', auth, (req, res) => {
   if (!isAdmin && !isOwner) {
     return res.status(403).json({ error: 'forbidden' })
   }
+  if (channel.avatar_url) {
+    const avatarPath = path.resolve(path.join(UPLOAD_DIR, channel.avatar_url))
+    if (avatarPath.startsWith(UPLOADS_ROOT) && fs.existsSync(avatarPath)) {
+      try {
+        fs.unlinkSync(avatarPath)
+      } catch (err) {
+        warn('[CHANNELS] avatar cleanup failed', err.message)
+      }
+    }
+  }
   const audience = getChannelAudienceUserIds(channel)
   const memberRows = listChannelMembersStmt.all(channel.id)
   const notifyIds = new Set(audience)
@@ -951,6 +1024,113 @@ app.delete('/api/channels/:id', auth, (req, res) => {
   emitChannelListForUsers(notifyList)
   log('[CHANNELS] delete', req.params.id, 'actor=' + req.user.id)
   res.json({ ok: true })
+})
+
+app.post('/api/channels/:id/avatar', auth, (req, res) => {
+  channelAvatarUpload.single('avatar')(req, res, (err) => {
+    if (err) {
+      warn('[CHANNELS] avatar upload failed', err?.message || err)
+      const code = err.code === 'LIMIT_FILE_SIZE' ? 'avatar_too_large' : 'invalid_avatar'
+      return res.status(400).json({ error: code })
+    }
+    if (!req.file) return res.status(400).json({ error: 'invalid_avatar' })
+
+    const viewer = selectUserById.get(req.user.id)
+    if (!viewer) return res.status(404).json({ error: 'not_found' })
+    const channel = selectChannelByIdStmt.get(req.params.id)
+    if (!channel) return res.status(404).json({ error: 'not_found' })
+    const access = resolveChannelAccess(viewer, channel.id)
+    if (!access.allowed && channel.is_private) return res.status(404).json({ error: 'not_found' })
+    const membershipRole = access.role || ''
+    const isCreator = !channel.is_private && channel.created_by && channel.created_by === viewer.id
+    const canManage = viewer.role === 'admin' || membershipRole === 'owner' || membershipRole === 'admin' || isCreator
+    if (!canManage) return res.status(403).json({ error: 'forbidden' })
+
+    const relPath = path.relative(UPLOAD_DIR, req.file.path)
+    const previousPath = channel.avatar_url ? path.join(UPLOAD_DIR, channel.avatar_url) : ''
+    updateChannelAvatarStmt.run(relPath, Date.now(), req.file.mimetype || '', channel.id)
+    if (previousPath && fs.existsSync(previousPath) && path.resolve(previousPath).startsWith(UPLOADS_ROOT)) {
+      if (path.resolve(previousPath) !== path.resolve(req.file.path)) {
+        try {
+          fs.unlinkSync(previousPath)
+        } catch (e) {
+          warn('[CHANNELS] avatar cleanup failed', e.message)
+        }
+      }
+    }
+
+    const updated = selectChannelByIdStmt.get(channel.id)
+    const audience = getChannelAudienceUserIds(updated)
+    emitChannelListForUsers(audience)
+    const updatedAccess = updated.is_private ? resolveChannelAccess(viewer, updated.id) : { allowed: true, role: '' }
+    const roleForResponse = updated.is_private
+      ? updatedAccess.role || (viewer.role === 'admin' ? 'admin' : '')
+      : viewer.role === 'admin'
+        ? 'admin'
+        : ''
+    const payload = publicChannel(updated, {
+      memberCount: updated.is_private ? getChannelMemberCount(updated.id) : 0,
+      membershipRole: roleForResponse,
+    })
+    log('[CHANNELS] avatar updated', updated.id, 'actor=' + viewer.id)
+    res.json({ channel: payload })
+  })
+})
+
+app.delete('/api/channels/:id/avatar', auth, (req, res) => {
+  const viewer = selectUserById.get(req.user.id)
+  if (!viewer) return res.status(404).json({ error: 'not_found' })
+  const channel = selectChannelByIdStmt.get(req.params.id)
+  if (!channel) return res.status(404).json({ error: 'not_found' })
+  const access = resolveChannelAccess(viewer, channel.id)
+  if (!access.allowed && channel.is_private) return res.status(404).json({ error: 'not_found' })
+  const membershipRole = access.role || ''
+  const isCreator = !channel.is_private && channel.created_by && channel.created_by === viewer.id
+  const canManage = viewer.role === 'admin' || membershipRole === 'owner' || membershipRole === 'admin' || isCreator
+  if (!canManage) return res.status(403).json({ error: 'forbidden' })
+
+  if (channel.avatar_url) {
+    const avatarPath = path.resolve(path.join(UPLOAD_DIR, channel.avatar_url))
+    if (avatarPath.startsWith(UPLOADS_ROOT) && fs.existsSync(avatarPath)) {
+      try {
+        fs.unlinkSync(avatarPath)
+      } catch (err) {
+        warn('[CHANNELS] avatar delete failed', err.message)
+      }
+    }
+  }
+  updateChannelAvatarStmt.run('', 0, '', channel.id)
+  const updated = selectChannelByIdStmt.get(channel.id)
+  emitChannelListForUsers(getChannelAudienceUserIds(updated))
+  const updatedAccess = updated.is_private ? resolveChannelAccess(viewer, updated.id) : { allowed: true, role: '' }
+  const roleForResponse = updated.is_private
+    ? updatedAccess.role || (viewer.role === 'admin' ? 'admin' : '')
+    : viewer.role === 'admin'
+      ? 'admin'
+      : ''
+  const payload = publicChannel(updated, {
+    memberCount: updated.is_private ? getChannelMemberCount(updated.id) : 0,
+    membershipRole: roleForResponse,
+  })
+  log('[CHANNELS] avatar removed', updated.id, 'actor=' + viewer.id)
+  res.json({ channel: payload })
+})
+
+app.get('/api/channels/:id/avatar', (req, res) => {
+  const channel = selectChannelByIdStmt.get(req.params.id)
+  if (!channel?.avatar_url) {
+    return res.status(404).json({ error: 'not_found' })
+  }
+  const avatarPath = path.resolve(path.join(UPLOAD_DIR, channel.avatar_url))
+  if (!avatarPath.startsWith(UPLOADS_ROOT)) return res.status(403).json({ error: 'forbidden' })
+  if (!fs.existsSync(avatarPath)) {
+    warn('[CHANNELS] avatar missing file', req.params.id)
+    return res.status(404).json({ error: 'missing_file' })
+  }
+  if (channel.avatar_mime) res.setHeader('Content-Type', channel.avatar_mime)
+  if (channel.avatar_updated_at) res.setHeader('Last-Modified', new Date(channel.avatar_updated_at).toUTCString())
+  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+  res.sendFile(avatarPath)
 })
 
 app.get('/api/users', auth, (req, res) => {
@@ -1099,7 +1279,7 @@ app.delete('/api/admin/users/:id', auth, adminOnly, (req, res) => {
 
 app.get('/api/voice-rooms', auth, (req, res) => {
   const viewer = selectUserById.get(req.user.id) || req.user
-  const rooms = getVoiceRoomsForUser(viewer).map((room) => formatVoiceRoom(room, viewer))
+  const rooms = getVoiceRoomsForUser(viewer).map((room) => publicVoiceRoom(room, viewer))
   res.json({ rooms })
 })
 
@@ -1119,7 +1299,7 @@ app.post('/api/voice-rooms', auth, (req, res) => {
     insertVoiceRoomMemberStmt.run(id, userId, adminSet.has(userId) ? 'admin' : 'member', now, viewer.id)
   })
   emitVoiceRoomsUpdate()
-  res.status(201).json({ room: formatVoiceRoom({ id, name, created_at: now, created_by: viewer.id }, viewer) })
+  res.status(201).json({ room: publicVoiceRoom({ id, name, created_at: now, created_by: viewer.id }, viewer) })
 })
 
 app.delete('/api/voice-rooms/:id', auth, (req, res) => {
@@ -1135,6 +1315,16 @@ app.delete('/api/voice-rooms/:id', auth, (req, res) => {
       if (targetSocket) {
         targetSocket.emit('voice:room-closed', { roomId: room.id })
         leaveVoiceRoom(targetSocket, { silent: true })
+      }
+    }
+  }
+  if (room.avatar_url) {
+    const avatarPath = path.resolve(path.join(UPLOAD_DIR, room.avatar_url))
+    if (avatarPath.startsWith(UPLOADS_ROOT) && fs.existsSync(avatarPath)) {
+      try {
+        fs.unlinkSync(avatarPath)
+      } catch (err) {
+        warn('[VOICE] avatar cleanup failed', err.message)
       }
     }
   }
@@ -1184,7 +1374,85 @@ app.post('/api/voice-rooms/:id/members', auth, (req, res) => {
   }
 
   emitVoiceRoomsUpdate()
-  res.json({ room: formatVoiceRoom({ ...room }, viewer) })
+  res.json({ room: publicVoiceRoom({ ...room }, viewer) })
+})
+
+app.post('/api/voice-rooms/:id/avatar', auth, (req, res) => {
+  voiceAvatarUpload.single('avatar')(req, res, (err) => {
+    if (err) {
+      warn('[VOICE] avatar upload failed', err?.message || err)
+      const code = err.code === 'LIMIT_FILE_SIZE' ? 'avatar_too_large' : 'invalid_avatar'
+      return res.status(400).json({ error: code })
+    }
+    if (!req.file) return res.status(400).json({ error: 'invalid_avatar' })
+
+    const viewer = selectUserById.get(req.user.id)
+    if (!viewer) return res.status(404).json({ error: 'not_found' })
+    const room = selectVoiceRoomStmt.get(req.params.id)
+    if (!room) return res.status(404).json({ error: 'not_found' })
+    if (!canManageVoiceRoom(viewer, room)) return res.status(403).json({ error: 'forbidden' })
+
+    const relPath = path.relative(UPLOAD_DIR, req.file.path)
+    const previousPath = room.avatar_url ? path.join(UPLOAD_DIR, room.avatar_url) : ''
+    updateVoiceRoomAvatarStmt.run(relPath, Date.now(), req.file.mimetype || '', room.id)
+    if (previousPath && fs.existsSync(previousPath) && path.resolve(previousPath).startsWith(UPLOADS_ROOT)) {
+      if (path.resolve(previousPath) !== path.resolve(req.file.path)) {
+        try {
+          fs.unlinkSync(previousPath)
+        } catch (error) {
+          warn('[VOICE] avatar cleanup failed', error.message)
+        }
+      }
+    }
+
+    const updated = selectVoiceRoomStmt.get(room.id)
+    const membership = selectVoiceRoomMemberStmt.get(room.id, viewer.id)
+    const payload = publicVoiceRoom({ ...updated, membership_role: membership?.role || '' }, viewer)
+    emitVoiceRoomsUpdate()
+    log('[VOICE] avatar updated', room.id, 'actor=' + viewer.id)
+    res.json({ room: payload })
+  })
+})
+
+app.delete('/api/voice-rooms/:id/avatar', auth, (req, res) => {
+  const viewer = selectUserById.get(req.user.id)
+  if (!viewer) return res.status(404).json({ error: 'not_found' })
+  const room = selectVoiceRoomStmt.get(req.params.id)
+  if (!room) return res.status(404).json({ error: 'not_found' })
+  if (!canManageVoiceRoom(viewer, room)) return res.status(403).json({ error: 'forbidden' })
+
+  if (room.avatar_url) {
+    const avatarPath = path.resolve(path.join(UPLOAD_DIR, room.avatar_url))
+    if (avatarPath.startsWith(UPLOADS_ROOT) && fs.existsSync(avatarPath)) {
+      try {
+        fs.unlinkSync(avatarPath)
+      } catch (err) {
+        warn('[VOICE] avatar delete failed', err.message)
+      }
+    }
+  }
+  updateVoiceRoomAvatarStmt.run('', 0, '', room.id)
+  const updated = selectVoiceRoomStmt.get(room.id)
+  const membership = selectVoiceRoomMemberStmt.get(room.id, viewer.id)
+  const payload = publicVoiceRoom({ ...updated, membership_role: membership?.role || '' }, viewer)
+  emitVoiceRoomsUpdate()
+  log('[VOICE] avatar removed', room.id, 'actor=' + viewer.id)
+  res.json({ room: payload })
+})
+
+app.get('/api/voice-rooms/:id/avatar', (req, res) => {
+  const room = selectVoiceRoomStmt.get(req.params.id)
+  if (!room?.avatar_url) return res.status(404).json({ error: 'not_found' })
+  const avatarPath = path.resolve(path.join(UPLOAD_DIR, room.avatar_url))
+  if (!avatarPath.startsWith(UPLOADS_ROOT)) return res.status(403).json({ error: 'forbidden' })
+  if (!fs.existsSync(avatarPath)) {
+    warn('[VOICE] avatar missing file', req.params.id)
+    return res.status(404).json({ error: 'missing_file' })
+  }
+  if (room.avatar_mime) res.setHeader('Content-Type', room.avatar_mime)
+  if (room.avatar_updated_at) res.setHeader('Last-Modified', new Date(room.avatar_updated_at).toUTCString())
+  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+  res.sendFile(avatarPath)
 })
 
 app.patch('/api/admin/users/:id/role', auth, adminOnly, (req, res) => {
@@ -1242,6 +1510,20 @@ app.delete('/api/admin/users/:id/avatar', auth, adminOnly, (req, res) => {
   res.json({ user: payload })
 })
 
+const imageFileFilter = (_req, file, cb) => {
+  if (!file?.mimetype?.startsWith('image/')) {
+    cb(new Error('invalid_avatar_type'))
+    return
+  }
+  cb(null, true)
+}
+
+const sanitizeForPath = (value, fallback = 'unknown') => {
+  if (!value || typeof value !== 'string') return fallback
+  const cleaned = value.replace(/[^a-zA-Z0-9_-]/g, '')
+  return cleaned || fallback
+}
+
 const avatarStorage = multer.diskStorage({
   destination: (req, _file, cb) => {
     const target = path.join(AVATAR_DIR, req.user.id)
@@ -1260,13 +1542,51 @@ const avatarStorage = multer.diskStorage({
 const avatarUpload = multer({
   storage: avatarStorage,
   limits: { fileSize: 5 * 1024 * 1024 },
-  fileFilter: (_req, file, cb) => {
-    if (!file?.mimetype?.startsWith('image/')) {
-      cb(new Error('invalid_avatar_type'))
-      return
-    }
-    cb(null, true)
+  fileFilter: imageFileFilter,
+})
+
+const channelAvatarStorage = multer.diskStorage({
+  destination: (req, _file, cb) => {
+    const safeId = sanitizeForPath(req.params?.id, 'unknown')
+    const target = path.join(CHANNEL_AVATAR_DIR, safeId)
+    fs.mkdirSync(target, { recursive: true })
+    cb(null, target)
   },
+  filename: (_req, file, cb) => {
+    const ext = (path.extname(file.originalname || '') || '.png').toLowerCase()
+    const allowed = ['.png', '.jpg', '.jpeg', '.gif', '.webp']
+    const safeExt = allowed.includes(ext) ? ext : '.png'
+    const name = Date.now().toString() + safeExt
+    cb(null, name)
+  },
+})
+
+const voiceAvatarStorage = multer.diskStorage({
+  destination: (req, _file, cb) => {
+    const safeId = sanitizeForPath(req.params?.id, 'unknown')
+    const target = path.join(VOICE_AVATAR_DIR, safeId)
+    fs.mkdirSync(target, { recursive: true })
+    cb(null, target)
+  },
+  filename: (_req, file, cb) => {
+    const ext = (path.extname(file.originalname || '') || '.png').toLowerCase()
+    const allowed = ['.png', '.jpg', '.jpeg', '.gif', '.webp']
+    const safeExt = allowed.includes(ext) ? ext : '.png'
+    const name = Date.now().toString() + safeExt
+    cb(null, name)
+  },
+})
+
+const channelAvatarUpload = multer({
+  storage: channelAvatarStorage,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: imageFileFilter,
+})
+
+const voiceAvatarUpload = multer({
+  storage: voiceAvatarStorage,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: imageFileFilter,
 })
 
 const upload = multer({ storage: multer.memoryStorage() })
@@ -1471,19 +1791,49 @@ const normalizeVoiceRoomMembers = (roomId) =>
     addedAt: member.added_at,
   }))
 
-const formatVoiceRoom = (room, viewer) => {
-  const baseRole = room.membership_role || (viewer?.id && room.created_by === viewer.id ? 'owner' : '')
-  const membershipRole = viewer?.role === 'admin' && !baseRole ? 'admin' : baseRole
-  const payload = {
+const normalizeVoiceRoomRow = (room) => {
+  if (!room) return null
+  const avatarPath = room.avatar_url ?? room.avatarUrl ?? ''
+  const avatarUpdatedAt = room.avatar_updated_at ?? room.avatarUpdatedAt ?? 0
+  return {
     id: room.id,
     name: room.name,
     createdAt: room.created_at,
     createdBy: room.created_by || '',
-    participantCount: voiceParticipants.get(room.id)?.size || 0,
-    membershipRole: membershipRole || '',
+    membershipRole: room.membership_role || room.membershipRole || '',
+    participantCount: room.participant_count ?? room.participantCount ?? 0,
+    avatarUrl: avatarPath ? `/api/voice-rooms/${room.id}/avatar` : '',
+    avatarUpdatedAt,
+    members: room.members,
   }
-  if (membershipRole === 'owner' || membershipRole === 'admin') {
-    payload.members = normalizeVoiceRoomMembers(room.id)
+}
+
+const publicVoiceRoom = (room, viewer, extras = {}) => {
+  if (!room) return null
+  const normalized = room && typeof room.createdAt !== 'undefined' && typeof room.membershipRole !== 'undefined'
+    ? room
+    : normalizeVoiceRoomRow(room)
+  if (!normalized) return null
+  const baseRole = normalized.membershipRole || (viewer?.id && normalized.createdBy === viewer.id ? 'owner' : '')
+  const membershipRole = viewer?.role === 'admin' && !baseRole ? 'admin' : baseRole
+  const participantCount =
+    typeof extras.participantCount === 'number'
+      ? extras.participantCount
+      : normalized.participantCount || voiceParticipants.get(normalized.id)?.size || 0
+  const payload = {
+    id: normalized.id,
+    name: normalized.name,
+    createdAt: normalized.createdAt,
+    createdBy: normalized.createdBy,
+    participantCount,
+    membershipRole: membershipRole || '',
+    avatarUrl: normalized.avatarUrl,
+    avatarUpdatedAt: normalized.avatarUpdatedAt,
+  }
+  if (Array.isArray(normalized.members)) {
+    payload.members = normalized.members
+  } else if (membershipRole === 'owner' || membershipRole === 'admin') {
+    payload.members = normalizeVoiceRoomMembers(normalized.id)
   }
   return payload
 }
@@ -1517,7 +1867,7 @@ const emitVoiceRoomsUpdate = () => {
   for (const socket of io.sockets.sockets.values()) {
     if (!socket.user) continue
     const rooms = getVoiceRoomsForUser(socket.user)
-    socket.emit('voice:rooms:update', { rooms: rooms.map((room) => formatVoiceRoom(room, socket.user)) })
+    socket.emit('voice:rooms:update', { rooms: rooms.map((room) => publicVoiceRoom(room, socket.user)) })
   }
 }
 


### PR DESCRIPTION
## Summary
- add avatar metadata to channel and voice room records and implement REST endpoints to upload, delete, and serve their avatars
- extend the client store with avatar normalization/helpers and upload/delete actions for channels and voice rooms
- update sidebar dialogs and lists to support selecting, previewing, and displaying channel and voice room avatars

## Testing
- npm --prefix server rebuild better-sqlite3 --loglevel error
- npm start
- npm install
- npm run dev -- --host 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68d6f0fd2ed48324ba4f39d124f2bc92