### PR TITLE
feat: support message replies

### DIFF
--- a/client/src/glass/components/ChatArea.jsx
+++ b/client/src/glass/components/ChatArea.jsx
@@ -280,7 +280,7 @@ const ChatArea = () => {
   const handleSubmit = (event) => {
     event.preventDefault();
     if (!content.trim() || !activeConversationId) return;
-    sendMessage(activeConversationId, content.trim());
+    sendMessage(content.trim());
     setTyping(activeConversationId, false);
     setContent("");
   };

--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -326,11 +326,40 @@ const enc = {
   },
 }
 
+const replyAttachmentPattern = /\[file:[^\]]+\]/g
+
+const buildReplyPreview = (content, fallback = 'Без текста') => {
+  if (typeof content !== 'string') return fallback
+  const attachments = content.match(replyAttachmentPattern) || []
+  const text = content.replace(replyAttachmentPattern, ' ').replace(/\s+/g, ' ').trim()
+  if (text) return text.length > 140 ? `${text.slice(0, 137)}...` : text
+  if (attachments.length === 1) return 'Вложение'
+  if (attachments.length > 1) return `Вложения (${attachments.length})`
+  return fallback
+}
+
 const formatMessage = (fallbackChannelId) => (raw) => {
   if (!raw) return null
   const channelId = raw.channelId ?? raw.channel_id ?? fallbackChannelId
   const senderId = raw.senderId ?? raw.sender_id ?? raw.user_id ?? null
   const createdAt = raw.createdAt ?? raw.created_at ?? Date.now()
+  const replyRaw = raw.replyTo ?? raw.reply_to ?? null
+  let replyTo = null
+  if (replyRaw?.id) {
+    const replyChannelId = replyRaw.channelId ?? replyRaw.channel_id ?? channelId
+    const encryptedReplyContent = replyRaw.content ?? replyRaw.reply_content ?? null
+    const decryptedReplyContent =
+      typeof encryptedReplyContent === 'string' ? enc.decrypt(replyChannelId, encryptedReplyContent) : ''
+    const replyFallback = encryptedReplyContent == null ? 'Сообщение недоступно' : 'Без текста'
+    const preview = buildReplyPreview(decryptedReplyContent, replyFallback)
+    replyTo = {
+      id: replyRaw.id,
+      authorId: replyRaw.senderId ?? replyRaw.sender_id ?? replyRaw.authorId ?? null,
+      author: replyRaw.senderUsername ?? replyRaw.sender_username ?? replyRaw.author ?? null,
+      preview,
+      missing: encryptedReplyContent == null,
+    }
+  }
   return {
     id: raw.id,
     channelId,
@@ -338,6 +367,7 @@ const formatMessage = (fallbackChannelId) => (raw) => {
     createdAt,
     updatedAt: raw.updatedAt ?? raw.updated_at ?? 0,
     content: enc.decrypt(channelId, raw.content),
+    replyTo,
   }
 }
 
@@ -1050,25 +1080,25 @@ const useStore = create((set, get) => ({
     socket.emit('channel:switch', { channelId })
   },
 
-  sendMessage: (content) => {
+  sendMessage: (content, replyTo = null) => {
     const socket = get().socket
     const channelId = get().activeChannelId
     if (!socket || !channelId || !content.trim()) return
     const encrypted = enc.encrypt(channelId, content.trim())
-    socket.emit('message:send', { channelId, content: encrypted })
+    socket.emit('message:send', { channelId, content: encrypted, replyTo: replyTo || null })
   },
 
-  editMessage: async (messageId, channelId, content) => {
+  editMessage: async (messageId, channelId, content, replyTo = undefined) => {
     const token = get().token
     if (!token) throw new Error('not_authenticated')
     const trimmed = typeof content === 'string' ? content.trim() : ''
     if (!trimmed) throw new Error('invalid_content')
     const encrypted = enc.encrypt(channelId, trimmed)
-    await axios.patch(
-      `${get().serverUrl}/api/messages/${messageId}`,
-      { content: encrypted },
-      { headers: buildAuthHeaders(token) },
-    )
+    const payload = { content: encrypted }
+    if (typeof replyTo !== 'undefined') payload.replyTo = replyTo
+    await axios.patch(`${get().serverUrl}/api/messages/${messageId}`, payload, {
+      headers: buildAuthHeaders(token),
+    })
   },
 
   deleteMessage: async (messageId) => {

--- a/client/src/ui/Chat.jsx
+++ b/client/src/ui/Chat.jsx
@@ -541,6 +541,7 @@ export default function Chat() {
   const [deleteDialog, setDeleteDialog] = useState(null)
   const [editDialog, setEditDialog] = useState(null)
   const [imagePreview, setImagePreview] = useState(null)
+  const [replyTarget, setReplyTarget] = useState(null)
   const [uploadDialog, setUploadDialog] = useState(null)
   const [membersDialogOpen, setMembersDialogOpen] = useState(false)
   const [membersLoading, setMembersLoading] = useState(false)
@@ -694,6 +695,35 @@ export default function Chat() {
   }
 
   const nameById = (id) => userMap.get(id)?.username || 'user'
+  const summarizeMessage = useCallback((message) => {
+    if (!message) return 'Без текста'
+    const { textSegments, attachments } = extractTextAndAttachments(message.content)
+    const text = textSegments.join(' ').trim()
+    if (text) return text.length > 140 ? `${text.slice(0, 137)}...` : text
+    if (attachments.length === 1) return 'Вложение'
+    if (attachments.length > 1) return `Вложения (${attachments.length})`
+    return 'Без текста'
+  }, [])
+
+  const handleSelectReply = useCallback(
+    (message) => {
+      if (!message) return
+      setReplyTarget({
+        id: message.id,
+        authorId: message.senderId,
+        author: nameById(message.senderId),
+        preview: summarizeMessage(message),
+      })
+      textareaRef.current?.focus()
+    },
+    [nameById, summarizeMessage],
+  )
+
+  const clearReplyTarget = useCallback(() => {
+    setReplyTarget(null)
+    textareaRef.current?.focus()
+  }, [])
+
   const avatarSrcById = (id) => {
     const user = userMap.get(id)
     return user ? buildAvatarUrl?.(user) : null
@@ -707,6 +737,17 @@ export default function Chat() {
   useEffect(() => {
     uploadDialogRef.current = uploadDialog
   }, [uploadDialog])
+
+  useEffect(() => {
+    setReplyTarget(null)
+  }, [activeChannelId])
+
+  useEffect(() => {
+    if (!replyTarget) return
+    if (!messages.some((message) => message.id === replyTarget.id)) {
+      setReplyTarget(null)
+    }
+  }, [messages, replyTarget])
 
   useEffect(
     () => () => {
@@ -949,8 +990,9 @@ export default function Chat() {
 
   const handleSend = () => {
     if (!text.trim()) return
-    sendMessage(text)
+    sendMessage(text, replyTarget?.id || null)
     setText('')
+    clearReplyTarget()
     if (typingTimeoutRef.current) {
       clearTimeout(typingTimeoutRef.current)
       typingTimeoutRef.current = null
@@ -1138,6 +1180,13 @@ export default function Chat() {
   const headerSubtitle = isDirectChannel
     ? 'Приватный диалог'
     : currentChannel ? 'Общий канал' : ''
+  const replyTargetAuthorName = replyTarget?.author || (replyTarget?.authorId ? nameById(replyTarget.authorId) : null)
+  const replyTargetAuthorLabel = replyTargetAuthorName
+    ? replyTargetAuthorName.startsWith('@')
+      ? replyTargetAuthorName
+      : `@${replyTargetAuthorName}`
+    : '@user'
+  const replyTargetPreviewText = replyTarget?.preview || 'Без текста'
 
   return (
     <div className="flex-1 flex flex-col h-full relative">
@@ -1176,6 +1225,16 @@ export default function Chat() {
           const canDelete = mine || me?.role === 'admin' || canModerateChannel
           const canEdit = mine || canModerateChannel
           const edited = m.updatedAt && m.updatedAt > (m.createdAt || 0)
+          const replyInfo = m.replyTo || null
+          const replyAuthorRaw = replyInfo?.author || (replyInfo?.authorId ? nameById(replyInfo.authorId) : null)
+          const replyAuthorLabel = replyAuthorRaw
+            ? replyAuthorRaw.startsWith('@')
+              ? replyAuthorRaw
+              : `@${replyAuthorRaw}`
+            : '@user'
+          const replyPreviewText = replyInfo
+            ? replyInfo.preview || (replyInfo.missing ? 'Сообщение недоступно' : 'Без текста')
+            : ''
           return (
             <div key={m.id} className={`max-w-[72%] px-4 py-3 rounded-3xl shadow-glass ${mine ? 'ml-auto panel' : 'glass'}`}>
               <div className="flex items-center justify-between text-[11px] text-white/70 mb-2">
@@ -1187,30 +1246,43 @@ export default function Chat() {
                     {edited ? ' · изменено' : ''}
                   </span>
                 </div>
-                {(canEdit || canDelete) && (
-                  <div className="flex items-center gap-2 text-white/40">
-                    {canEdit && (
-                      <button
-                        type="button"
-                        className="hover:text-white transition"
-                        onClick={() => handleRequestEdit(m)}
-                      >
-                        <EditIcon />
-                      </button>
-                    )}
-                    {canDelete && (
-                      <button
-                        type="button"
-                        className="hover:text-red-400 transition"
-                        onClick={() => handleRequestDelete(m)}
-                      >
-                        <TrashIcon />
-                      </button>
-                    )}
-                  </div>
-                )}
+                <div className="flex items-center gap-2 text-white/40">
+                  <button
+                    type="button"
+                    className="text-xs uppercase tracking-[0.12em] hover:text-white transition"
+                    onClick={() => handleSelectReply(m)}
+                  >
+                    Ответить
+                  </button>
+                  {canEdit && (
+                    <button
+                      type="button"
+                      className="hover:text-white transition"
+                      onClick={() => handleRequestEdit(m)}
+                    >
+                      <EditIcon />
+                    </button>
+                  )}
+                  {canDelete && (
+                    <button
+                      type="button"
+                      className="hover:text-red-400 transition"
+                      onClick={() => handleRequestDelete(m)}
+                    >
+                      <TrashIcon />
+                    </button>
+                  )}
+                </div>
               </div>
               <div className="whitespace-pre-wrap leading-relaxed break-words space-y-3">
+                {replyInfo && (
+                  <div className="px-3 py-2 rounded-2xl bg-white/5 border border-white/10">
+                    <div className="text-xs text-white/50 mb-1">Ответ {replyAuthorLabel}</div>
+                    <div className="text-sm text-white/80 whitespace-pre-wrap break-words">
+                      {replyPreviewText}
+                    </div>
+                  </div>
+                )}
                 {textSegments.filter((segment) => segment && segment.trim()).map((segment, idx) => (
                   <div key={`text-${m.id}-${idx}`}>{segment}</div>
                 ))}
@@ -1236,6 +1308,24 @@ export default function Chat() {
       )}
 
       <div className="px-6 py-4 border-t border-white/10">
+        {replyTarget && (
+          <div className="mb-3 px-4 py-3 rounded-2xl bg-white/10 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-xs text-white/60 uppercase tracking-[0.15em] mb-1">Ответ {replyTargetAuthorLabel}</div>
+              <div className="text-sm text-white/80 whitespace-pre-wrap break-words max-h-24 overflow-hidden">
+                {replyTargetPreviewText}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={clearReplyTarget}
+              className="text-white/60 hover:text-white transition"
+              title="Отменить ответ"
+            >
+              ✕
+            </button>
+          </div>
+        )}
         <div className="panel rounded-3xl px-4 py-2 flex items-center gap-3">
           <IconButton onClick={handleFilePick} title="Прикрепить файлы">
             <PaperclipIcon />

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -225,7 +225,8 @@ CREATE TABLE IF NOT EXISTS messages (
   sender_id TEXT NOT NULL,
   content TEXT NOT NULL,
   created_at INTEGER NOT NULL,
-  updated_at INTEGER DEFAULT 0
+  updated_at INTEGER DEFAULT 0,
+  reply_to TEXT REFERENCES messages(id) ON DELETE SET NULL
 );
 CREATE TABLE IF NOT EXISTS channel_members (
   channel_id TEXT NOT NULL,
@@ -291,8 +292,10 @@ ensureColumn('invites', 'revoked_at', 'INTEGER')
 ensureColumn('channels', 'is_private', 'INTEGER NOT NULL DEFAULT 0')
 ensureColumn('channels', 'created_by', 'TEXT DEFAULT ""')
 ensureColumn('messages', 'updated_at', 'INTEGER DEFAULT 0')
+ensureColumn('messages', 'reply_to', 'TEXT REFERENCES messages(id) ON DELETE SET NULL')
 
 const hasMessageUpdatedAtColumn = tableHasColumn('messages', 'updated_at')
+const hasMessageReplyColumn = tableHasColumn('messages', 'reply_to')
 
 try {
   db.prepare('ALTER TABLE users ADD COLUMN avatar_seed TEXT DEFAULT ""').run()
@@ -335,6 +338,9 @@ try {
 } catch (err) {}
 try {
   db.prepare('ALTER TABLE messages ADD COLUMN updated_at INTEGER DEFAULT 0').run()
+} catch (err) {}
+try {
+  db.prepare('ALTER TABLE messages ADD COLUMN reply_to TEXT REFERENCES messages(id) ON DELETE SET NULL').run()
 } catch (err) {}
 
 
@@ -379,12 +385,41 @@ const updateInviteClaimStmt = db.prepare('UPDATE invites SET claim_token=?, clai
 const clearInviteClaimStmt = db.prepare("UPDATE invites SET claim_token='', claimed_at=NULL WHERE id=?")
 const markInviteUsedStmt = db.prepare("UPDATE invites SET used_by=?, used_at=?, claim_token='', revoked_at=NULL WHERE id=?")
 const revokeInviteStmt = db.prepare("UPDATE invites SET revoked_at=?, claim_token='' WHERE id=?")
-const findMessageById = db.prepare('SELECT id, channel_id, sender_id FROM messages WHERE id=?')
-const selectMessageFullById = db.prepare('SELECT * FROM messages WHERE id=?')
+const findMessageById = hasMessageReplyColumn
+  ? db.prepare('SELECT id, channel_id, sender_id, reply_to FROM messages WHERE id=?')
+  : db.prepare('SELECT id, channel_id, sender_id FROM messages WHERE id=?')
+
+const messageSelectBase = hasMessageReplyColumn
+  ? `SELECT m.*, parent.sender_id AS reply_sender_id, parent.content AS reply_content, parent.created_at AS reply_created_at,
+     parent.updated_at AS reply_updated_at, parent_user.username AS reply_sender_username
+     FROM messages m
+     LEFT JOIN messages parent ON parent.id = m.reply_to
+     LEFT JOIN users parent_user ON parent_user.id = parent.sender_id`
+  : 'SELECT * FROM messages'
+
+const selectMessageFullById = hasMessageReplyColumn
+  ? db.prepare(`${messageSelectBase} WHERE m.id=?`)
+  : db.prepare('SELECT * FROM messages WHERE id=?')
 const deleteMessageStmt = db.prepare('DELETE FROM messages WHERE id=?')
-const updateMessageContentStmt = hasMessageUpdatedAtColumn
-  ? db.prepare('UPDATE messages SET content=?, updated_at=? WHERE id=?')
-  : db.prepare('UPDATE messages SET content=? WHERE id=?')
+const clearMessageRepliesStmt = hasMessageReplyColumn
+  ? db.prepare('UPDATE messages SET reply_to=NULL WHERE reply_to=?')
+  : null
+const updateMessageContentStmt = (() => {
+  if (hasMessageReplyColumn && hasMessageUpdatedAtColumn) {
+    const stmt = db.prepare('UPDATE messages SET content=?, updated_at=?, reply_to=? WHERE id=?')
+    return (content, updatedAt, replyTo, id) => stmt.run(content, updatedAt, replyTo || null, id)
+  }
+  if (hasMessageReplyColumn) {
+    const stmt = db.prepare('UPDATE messages SET content=?, reply_to=? WHERE id=?')
+    return (content, _updatedAt, replyTo, id) => stmt.run(content, replyTo || null, id)
+  }
+  if (hasMessageUpdatedAtColumn) {
+    const stmt = db.prepare('UPDATE messages SET content=?, updated_at=? WHERE id=?')
+    return (content, updatedAt, _replyTo, id) => stmt.run(content, updatedAt, id)
+  }
+  const stmt = db.prepare('UPDATE messages SET content=? WHERE id=?')
+  return (content, _updatedAt, _replyTo, id) => stmt.run(content, id)
+})()
 const selectChannelByIdStmt = db.prepare('SELECT * FROM channels WHERE id=?')
 const insertChannelStmt = db.prepare(
   'INSERT INTO channels (id, workspace_id, name, created_at, is_private, created_by) VALUES (?,?,?,?,?,?)',
@@ -404,14 +439,54 @@ const findChannelMemberStmt = db.prepare('SELECT role FROM channel_members WHERE
 const countChannelMembersStmt = db.prepare('SELECT COUNT(*) as count FROM channel_members WHERE channel_id=?')
 const listAdminsStmt = db.prepare("SELECT id FROM users WHERE role='admin'")
 
-const decryptMessageRow = (row) => {
-  if (!row) return row
-  if (typeof row.content === 'undefined') return row
+const publicMessage = (row) => {
+  if (!row || typeof row.content === 'undefined') return row
   const updatedAt = row.updated_at ?? row.updatedAt ?? 0
-  return { ...row, content: decryptText(row.content), updated_at: updatedAt, updatedAt }
+  const channelId = row.channel_id ?? row.channelId ?? null
+  const senderId = row.sender_id ?? row.senderId ?? null
+  const createdAt = row.created_at ?? row.createdAt ?? Date.now()
+  const payload = {
+    ...row,
+    channel_id: row.channel_id ?? row.channelId ?? channelId,
+    channelId,
+    sender_id: senderId,
+    senderId,
+    created_at: createdAt,
+    createdAt,
+    content: decryptText(row.content),
+    updated_at: updatedAt,
+    updatedAt,
+  }
+  if (hasMessageReplyColumn) {
+    const replyId = row.reply_to ?? row.replyTo ?? null
+    if (replyId) {
+      const replyContentRaw = typeof row.reply_content === 'undefined' ? null : decryptText(row.reply_content)
+      const replySenderId = row.reply_sender_id ?? row.replySenderId ?? null
+      const replySenderUsername = row.reply_sender_username ?? row.replySenderUsername ?? null
+      const replyCreatedAt = row.reply_created_at ?? row.replyCreatedAt ?? 0
+      const replyUpdatedAt = row.reply_updated_at ?? row.replyUpdatedAt ?? 0
+      payload.replyTo = {
+        id: replyId,
+        senderId: replySenderId,
+        senderUsername: replySenderUsername,
+        content: replyContentRaw,
+        createdAt: replyCreatedAt,
+        updatedAt: replyUpdatedAt,
+      }
+    } else {
+      payload.replyTo = null
+    }
+    delete payload.reply_content
+    delete payload.reply_sender_id
+    delete payload.reply_sender_username
+    delete payload.reply_created_at
+    delete payload.reply_updated_at
+  }
+  if (typeof payload.replyTo === 'undefined') payload.replyTo = null
+  return payload
 }
 
-const decryptMessages = (rows) => rows.map(decryptMessageRow)
+const publicMessages = (rows) => rows.map(publicMessage)
 
 let defaultWs = db.prepare('SELECT id FROM workspaces LIMIT 1').get()
 if (!defaultWs) {
@@ -1382,6 +1457,7 @@ app.delete('/api/messages/:id', auth, (req, res) => {
   }
   if (message.sender_id !== req.user.id && req.user.role !== 'admin' && !isChannelOwner)
     return res.status(403).json({ error: 'forbidden' })
+  if (clearMessageRepliesStmt) clearMessageRepliesStmt.run(message.id)
   deleteMessageStmt.run(message.id)
   io.to(message.channel_id).emit('message:deleted', { id: message.id, channelId: message.channel_id })
   if (message.channel_id.startsWith('dm:')) {
@@ -1412,22 +1488,31 @@ app.patch('/api/messages/:id', auth, (req, res) => {
   if (message.sender_id !== req.user.id && req.user.role !== 'admin' && !isChannelOwner)
     return res.status(403).json({ error: 'forbidden' })
 
-  const updatedAtRaw = Date.now()
-  if (hasMessageUpdatedAtColumn) {
-    updateMessageContentStmt.run(encryptText(rawContent), updatedAtRaw, message.id)
-  } else {
-    updateMessageContentStmt.run(encryptText(rawContent), message.id)
+  let nextReplyId = null
+  if (hasMessageReplyColumn) {
+    const bodyHasReply = Object.prototype.hasOwnProperty.call(req.body || {}, 'replyTo')
+    if (bodyHasReply) {
+      const rawReply = req.body.replyTo
+      if (rawReply === null || rawReply === '' || typeof rawReply === 'undefined') {
+        nextReplyId = null
+      } else if (typeof rawReply === 'string') {
+        const parent = findMessageById.get(rawReply)
+        if (!parent || parent.channel_id !== message.channel_id) return res.status(400).json({ error: 'invalid_reply' })
+        nextReplyId = rawReply
+      } else {
+        return res.status(400).json({ error: 'invalid_reply' })
+      }
+    } else {
+      nextReplyId = message.reply_to ?? null
+    }
   }
-  const updatedAt = hasMessageUpdatedAtColumn ? updatedAtRaw : 0
 
-  const payload = {
-    id: message.id,
-    channelId: message.channel_id,
-    senderId: message.sender_id,
-    content: rawContent,
-    createdAt: message.created_at,
-    updatedAt,
-  }
+  const updatedAtRaw = Date.now()
+  updateMessageContentStmt(encryptText(rawContent), updatedAtRaw, nextReplyId, message.id)
+
+  const fresh = selectMessageFullById.get(message.id)
+  const payload = publicMessage(fresh)
+
   io.to(message.channel_id).emit('message:updated', payload)
   if (message.channel_id.startsWith('dm:')) {
     const participants = parseDirectChannelId(message.channel_id)
@@ -1445,11 +1530,40 @@ app.patch('/api/messages/:id', auth, (req, res) => {
 })
 
 const onlineUsers = new Map()
-const listMessages = db.prepare('SELECT * FROM messages WHERE channel_id=? ORDER BY created_at DESC LIMIT ? OFFSET ?')
+const listMessages = hasMessageReplyColumn
+  ? db.prepare(
+      `${messageSelectBase} WHERE m.channel_id=? ORDER BY m.created_at DESC LIMIT ? OFFSET ?`,
+    )
+  : db.prepare('SELECT * FROM messages WHERE channel_id=? ORDER BY created_at DESC LIMIT ? OFFSET ?')
 
-const insertMessage = hasMessageUpdatedAtColumn
-  ? db.prepare('INSERT INTO messages (id,channel_id,sender_id,content,created_at,updated_at) VALUES (?,?,?,?,?,0)')
-  : db.prepare('INSERT INTO messages (id,channel_id,sender_id,content,created_at) VALUES (?,?,?,?,?)')
+const insertMessage = (() => {
+  if (hasMessageReplyColumn && hasMessageUpdatedAtColumn) {
+    const stmt = db.prepare(
+      'INSERT INTO messages (id,channel_id,sender_id,content,created_at,updated_at,reply_to) VALUES (?,?,?,?,?,0,?)',
+    )
+    return {
+      run: (id, channelId, senderId, content, createdAt, replyTo) => stmt.run(id, channelId, senderId, content, createdAt, replyTo || null),
+    }
+  }
+  if (hasMessageReplyColumn) {
+    const stmt = db.prepare(
+      'INSERT INTO messages (id,channel_id,sender_id,content,created_at,reply_to) VALUES (?,?,?,?,?,?)',
+    )
+    return {
+      run: (id, channelId, senderId, content, createdAt, replyTo) => stmt.run(id, channelId, senderId, content, createdAt, replyTo || null),
+    }
+  }
+  if (hasMessageUpdatedAtColumn) {
+    const stmt = db.prepare('INSERT INTO messages (id,channel_id,sender_id,content,created_at,updated_at) VALUES (?,?,?,?,?,0)')
+    return {
+      run: (id, channelId, senderId, content, createdAt) => stmt.run(id, channelId, senderId, content, createdAt),
+    }
+  }
+  const stmt = db.prepare('INSERT INTO messages (id,channel_id,sender_id,content,created_at) VALUES (?,?,?,?,?)')
+  return {
+    run: (id, channelId, senderId, content, createdAt) => stmt.run(id, channelId, senderId, content, createdAt),
+  }
+})()
 
 const voiceParticipants = new Map()
 const typingState = new Map()
@@ -1718,7 +1832,7 @@ io.on('connection', (socket) => {
       if (currentChannelId) ensureChannelJoined(currentChannelId)
       else leaveMessageRooms()
     }
-    const messages = currentChannelId ? decryptMessages(listMessages.all(currentChannelId, limit, offset)).reverse() : []
+    const messages = currentChannelId ? publicMessages(listMessages.all(currentChannelId, limit, offset)).reverse() : []
     socket.emit('init:response', { workspaces: [{ id: wsId, name: 'Home' }], channels, activeChannelId: currentChannelId, messages })
   })
 
@@ -1731,7 +1845,7 @@ io.on('connection', (socket) => {
       const normalized = normalizeDirectChannelId(channelId)
       if (!normalized) return
       ensureChannelJoined(normalized)
-      const msgs = decryptMessages(listMessages.all(normalized, 50, 0)).reverse()
+      const msgs = publicMessages(listMessages.all(normalized, 50, 0)).reverse()
       socket.emit('channel:opened', { channelId: normalized, messages: msgs })
       return
     }
@@ -1739,11 +1853,11 @@ io.on('connection', (socket) => {
     const access = resolveChannelAccess(userRecord, channelId)
     if (!access.allowed) return
     ensureChannelJoined(channelId)
-    const msgs = decryptMessages(listMessages.all(channelId, 50, 0)).reverse()
+    const msgs = publicMessages(listMessages.all(channelId, 50, 0)).reverse()
     socket.emit('channel:opened', { channelId, messages: msgs })
   })
 
-  socket.on('message:send', ({ channelId, content }) => {
+  socket.on('message:send', ({ channelId, content, replyTo }) => {
     if (!channelId || !content) return
     let targetChannel = channelId
     let directParticipants = null
@@ -1760,11 +1874,24 @@ io.on('connection', (socket) => {
       if (!access.allowed) return
       targetChannel = channelId
     }
+    let replyTargetId = null
+    if (hasMessageReplyColumn) {
+      if (replyTo === null || typeof replyTo === 'undefined' || replyTo === '') {
+        replyTargetId = null
+      } else if (typeof replyTo === 'string') {
+        const parent = findMessageById.get(replyTo)
+        if (!parent || parent.channel_id !== targetChannel) return
+        replyTargetId = replyTo
+      } else {
+        return
+      }
+    }
     const id = uuidv4()
     const now = Date.now()
     const encryptedContent = encryptText(content)
-    insertMessage.run(id, targetChannel, userId, encryptedContent, now)
-    const payload = { id, channelId: targetChannel, senderId: userId, content, createdAt: now, updatedAt: 0 }
+    insertMessage.run(id, targetChannel, userId, encryptedContent, now, replyTargetId)
+    const inserted = selectMessageFullById.get(id)
+    const payload = publicMessage(inserted)
     io.to(targetChannel).emit('message:new', payload)
     log('[MESSAGE] send', 'user=' + userId, 'channel=' + targetChannel, 'bytes=' + Buffer.byteLength(content, 'utf8'))
     if (directParticipants) {
@@ -1794,7 +1921,7 @@ io.on('connection', (socket) => {
       if (!access.allowed) return
       targetChannel = channelId
     }
-    const msgs = decryptMessages(listMessages.all(targetChannel, limit, offset)).reverse()
+    const msgs = publicMessages(listMessages.all(targetChannel, limit, offset)).reverse()
     socket.emit('messages:page', { channelId: targetChannel, messages: msgs, offset, limit })
   })
 


### PR DESCRIPTION
## Summary
- add a reply_to column and expose parent message metadata in server API/socket payloads
- validate reply targets when sending/updating messages and include quote data in broadcasts
- update the client state and chat UI to send replies, show quote previews, and allow clearing the selection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f0fd794483248e749eb97df1d6a1