### PR TITLE
Add embedded backend for desktop app

### DIFF
--- a/client/electron/main.js
+++ b/client/electron/main.js
@@ -1,11 +1,168 @@
 import { app, BrowserWindow, ipcMain, Notification } from 'electron'
 import path from 'path'
-import { fileURLToPath } from 'url'
+import fs from 'fs'
+import crypto from 'crypto'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 let win = null
+let backendInfo = null
+let backendModule = null
+let backendStartPromise = null
+let backendStopPromise = null
+let backendUrl = null
+
+const DEFAULT_BACKEND_HOST = '127.0.0.1'
+const DEFAULT_BACKEND_PORT = 48080
+
+const resolveServerRoot = () => {
+  if (app?.isPackaged) {
+    return path.join(process.resourcesPath, 'server')
+  }
+  return path.resolve(__dirname, '..', '..', 'server')
+}
+
+const loadEnvFile = (filePath) => {
+  const env = {}
+  try {
+    if (!fs.existsSync(filePath)) return env
+    const raw = fs.readFileSync(filePath, 'utf8')
+    raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'))
+      .forEach((line) => {
+        const eqIndex = line.indexOf('=')
+        if (eqIndex <= 0) return
+        const key = line.slice(0, eqIndex).trim()
+        const value = line.slice(eqIndex + 1).trim()
+        if (key) env[key] = value
+      })
+  } catch (err) {
+    console.warn('[main] failed to load env file', filePath, err)
+  }
+  return env
+}
+
+const readPersistedBackendConfig = (filePath) => {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    const raw = fs.readFileSync(filePath, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') return parsed
+  } catch (err) {
+    console.warn('[main] failed to read backend config', err)
+  }
+  return {}
+}
+
+const writePersistedBackendConfig = (filePath, config) => {
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, JSON.stringify(config, null, 2), 'utf8')
+  } catch (err) {
+    console.warn('[main] failed to persist backend config', err)
+  }
+}
+
+const notifyBackendReady = (url) => {
+  if (!url) return
+  backendUrl = url
+  BrowserWindow.getAllWindows().forEach((window) => {
+    try {
+      window.webContents.send('backend:ready', url)
+    } catch (err) {
+      console.warn('[main] failed to notify backend ready', err)
+    }
+  })
+}
+
+const ensureBackend = async () => {
+  if (backendInfo) return backendInfo
+  if (backendStartPromise) return backendStartPromise
+
+  backendStartPromise = (async () => {
+    const serverRoot = resolveServerRoot()
+    const envFromFile = loadEnvFile(path.join(serverRoot, '.env'))
+    const dataRoot = path.join(app.getPath('userData'), 'backend')
+    fs.mkdirSync(dataRoot, { recursive: true })
+
+    const bundledDbPath = path.join(serverRoot, 'messenger_v4.db')
+    const targetDbPath = path.join(dataRoot, 'messenger_v4.db')
+    try {
+      if (!fs.existsSync(targetDbPath) && fs.existsSync(bundledDbPath)) {
+        fs.copyFileSync(bundledDbPath, targetDbPath)
+      }
+    } catch (err) {
+      console.warn('[main] failed to prepare bundled database', err)
+    }
+
+    const persistedConfigPath = path.join(dataRoot, 'config.json')
+    const persisted = readPersistedBackendConfig(persistedConfigPath)
+
+    const host = process.env.NE_BACKEND_HOST || persisted.host || envFromFile.HOST || DEFAULT_BACKEND_HOST
+    const port = Number(process.env.NE_BACKEND_PORT || persisted.port || envFromFile.PORT || DEFAULT_BACKEND_PORT)
+
+    const encryptionKey =
+      process.env.ENCRYPTION_KEY || persisted.encryptionKey || envFromFile.ENCRYPTION_KEY || crypto.randomBytes(32).toString('base64')
+    const jwtSecret = process.env.JWT_SECRET || persisted.jwtSecret || envFromFile.JWT_SECRET || crypto.randomBytes(32).toString('base64')
+
+    const uploadsDir = path.join(dataRoot, 'uploads')
+    fs.mkdirSync(uploadsDir, { recursive: true })
+
+    process.env.NE_MESSENGER_DATA_ROOT = dataRoot
+    process.env.PORT = String(port)
+    process.env.JWT_SECRET = jwtSecret
+    process.env.ENCRYPTION_KEY = encryptionKey
+    process.env.UPLOAD_DIR = uploadsDir
+
+    const moduleUrl = pathToFileURL(path.join(serverRoot, 'src/index.js')).href
+    const mod = await import(moduleUrl)
+    if (typeof mod.startMessengerServer !== 'function') {
+      throw new Error('startMessengerServer export not found')
+    }
+    backendModule = mod
+    const result = await mod.startMessengerServer({ host, port })
+    const resolvedPort = result?.port ?? port
+    const resolvedHost = result?.host ?? host
+    backendInfo = { ...result, port: resolvedPort, host: resolvedHost }
+    const baseUrl = `http://${resolvedHost}:${resolvedPort}`
+    backendInfo.url = baseUrl
+    writePersistedBackendConfig(persistedConfigPath, {
+      host: resolvedHost,
+      port: resolvedPort,
+      encryptionKey,
+      jwtSecret,
+    })
+    notifyBackendReady(baseUrl)
+    return backendInfo
+  })()
+
+  try {
+    return await backendStartPromise
+  } finally {
+    backendStartPromise = null
+  }
+}
+
+const stopBackend = async () => {
+  if (backendStopPromise) return backendStopPromise
+  if (!backendModule?.stopMessengerServer) return Promise.resolve(null)
+  backendStopPromise = backendModule
+    .stopMessengerServer()
+    .catch((err) => {
+      console.warn('[main] failed to stop backend', err)
+    })
+    .finally(() => {
+      backendStopPromise = null
+      backendInfo = null
+      backendModule = null
+      backendUrl = null
+    })
+  return backendStopPromise
+}
 
 const isAutostartSupported = () => {
   if (process.platform !== 'darwin' && process.platform !== 'win32') return false
@@ -77,6 +234,7 @@ const registerIpcHandlers = () => {
   ipcMain.removeHandler('autostart:get')
   ipcMain.removeHandler('autostart:set')
   ipcMain.removeHandler('autostart:is-supported')
+  ipcMain.removeHandler('backend:get-url')
 
   ipcMain.handle('window:get-state', () => getWindowState())
 
@@ -119,6 +277,15 @@ const registerIpcHandlers = () => {
   ipcMain.handle('autostart:is-supported', () => isAutostartSupported())
   ipcMain.handle('autostart:get', () => getAutostartEnabled())
   ipcMain.handle('autostart:set', (_event, enabled) => setAutostartEnabled(Boolean(enabled)))
+  ipcMain.handle('backend:get-url', async () => {
+    try {
+      const info = await ensureBackend()
+      return info?.url ?? backendUrl ?? null
+    } catch (err) {
+      console.error('[main] backend:get-url failed', err)
+      return backendUrl ?? null
+    }
+  })
 
   // Global notification IPC handler used by renderer via preload
   ipcMain.on('notify', (_event, rawPayload) => {
@@ -170,7 +337,7 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       sandbox: false,
-  preload: path.join(__dirname, 'preload.cjs'),
+      preload: path.join(__dirname, 'preload.cjs'),
     },
   })
 
@@ -179,6 +346,29 @@ function createWindow() {
   else win.loadFile(path.join(__dirname, '../renderer/index.html'))
 
   registerIpcHandlers()
+
+  if (backendUrl) {
+    win.webContents.once('did-finish-load', () => {
+      try {
+        win?.webContents.send('backend:ready', backendUrl)
+      } catch (err) {
+        console.warn('[main] failed to deliver backend url to renderer', err)
+      }
+    })
+  }
+
+  ensureBackend()
+    .then((info) => {
+      if (!info?.url) return
+      try {
+        win?.webContents.send('backend:ready', info.url)
+      } catch (err) {
+        console.warn('[main] failed to send backend url after init', err)
+      }
+    })
+    .catch((err) => {
+      console.error('[main] ensureBackend during window init failed', err)
+    })
 
   win.on('maximize', sendWindowState)
   win.on('unmaximize', sendWindowState)
@@ -189,13 +379,22 @@ function createWindow() {
   })
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  try {
+    await ensureBackend()
+  } catch (err) {
+    console.error('[main] failed to start backend', err)
+  }
   createWindow()
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow()
     }
   })
+})
+
+app.on('before-quit', () => {
+  stopBackend()
 })
 
 app.on('window-all-closed', () => {

--- a/client/electron/preload.cjs
+++ b/client/electron/preload.cjs
@@ -47,5 +47,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   getAutostartStatus: () => ipcRenderer.invoke('autostart:get').catch(() => false),
   setAutostartStatus: (enabled) => ipcRenderer.invoke('autostart:set', Boolean(enabled)),
-  isAutostartSupported: () => ipcRenderer.invoke('autostart:is-supported').catch(() => false)
+  isAutostartSupported: () => ipcRenderer.invoke('autostart:is-supported').catch(() => false),
+  getBackendUrl: () => ipcRenderer.invoke('backend:get-url').catch(() => null),
+  onBackendReady: (cb) => {
+    if (typeof cb !== 'function') return () => {}
+    const handler = (_event, url) => cb(url)
+    ipcRenderer.on('backend:ready', handler)
+    return () => ipcRenderer.removeListener('backend:ready', handler)
+  },
 })

--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,20 @@
             "assets/**",
             "package.json"
         ],
+        "extraResources": [
+            {
+                "from": "../server",
+                "to": "server",
+                "filter": [
+                    "**/*"
+                ]
+            }
+        ],
         "asar": true,
+        "asarUnpack": [
+            "server/node_modules/**/build/Release/*.node",
+            "server/node_modules/**/*.node"
+        ],
         "win": {
             "target": [
                 "nsis"

--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -26,6 +26,8 @@ const DEFAULT_APPEARANCE = Object.freeze({
   noiseStrength: 0.12,
 })
 
+const DEFAULT_SERVER_URL = import.meta.env.VITE_LGM_SERVER || 'http://127.0.0.1:48080'
+
 const clamp = (value, min, max) => {
   if (!Number.isFinite(value)) return min
   if (value < min) return min
@@ -603,8 +605,36 @@ const buildAuthHeaders = (token) => ({ Authorization: `Bearer ${token}` })
 
 const initialAuth = loadStoredAuth()
 
+const integrateElectronBackend = (set, get) => {
+  if (typeof window === 'undefined') return
+  const api = window.electronAPI
+  if (!api) return
+  const applyUrl = (url) => {
+    if (!url || typeof url !== 'string') return
+    const normalized = url.trim()
+    if (!normalized.length) return
+    let shouldReconnect = false
+    set((state) => {
+      if (state.serverUrl === normalized) return state
+      if (state.token) shouldReconnect = true
+      return { serverUrl: normalized }
+    })
+    if (shouldReconnect) {
+      try {
+        get().connect()
+      } catch (err) {
+        console.warn('connect after backend url update failed', err)
+      }
+    }
+  }
+  api.getBackendUrl?.().then(applyUrl).catch((err) => console.warn('backend url resolve failed', err))
+  if (typeof api.onBackendReady === 'function') {
+    api.onBackendReady((url) => applyUrl(url))
+  }
+}
+
 const useStore = create((set, get) => ({
-  serverUrl: import.meta.env.VITE_LGM_SERVER || 'http://localhost:4000',
+  serverUrl: DEFAULT_SERVER_URL,
   token: initialAuth.token,
   user: initialAuth.user,
   users: [],
@@ -1993,5 +2023,10 @@ const useStore = create((set, get) => ({
     return normalized
   },
 }))
+
+if (typeof window !== 'undefined') {
+  const scheduleBackendIntegration = typeof queueMicrotask === 'function' ? queueMicrotask : (cb) => setTimeout(cb, 0)
+  scheduleBackendIntegration(() => integrateElectronBackend(useStore.setState, useStore.getState))
+}
 
 export default useStore

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -12,6 +12,26 @@ import path from 'path'
 import multer from 'multer'
 import crypto from 'crypto'
 import mime from 'mime-types'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const resolveDataRoot = () => {
+  const candidate = process.env.NE_MESSENGER_DATA_ROOT
+  if (candidate && typeof candidate === 'string' && candidate.trim().length) {
+    return path.resolve(candidate)
+  }
+  return path.resolve(__dirname, '..')
+}
+
+const DATA_ROOT = resolveDataRoot()
+
+const resolveDataPath = (maybePath, fallback) => {
+  const base = typeof maybePath === 'string' && maybePath.trim().length ? maybePath.trim() : fallback
+  if (!base) return DATA_ROOT
+  return path.isAbsolute(base) ? base : path.join(DATA_ROOT, base)
+}
 
 const app = express()
 const server = http.createServer(app)
@@ -154,19 +174,24 @@ app.use((req, res, next) => {
 
 const PORT = process.env.PORT || 4000
 const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret'
-const UPLOAD_DIR = process.env.UPLOAD_DIR || 'uploads'
+const DB_PATH = resolveDataPath(process.env.DB_FILE, 'messenger_v4.db')
+const DB_DIR = path.dirname(DB_PATH)
+if (!fs.existsSync(DB_DIR)) fs.mkdirSync(DB_DIR, { recursive: true })
+
+const UPLOAD_DIR = resolveDataPath(process.env.UPLOAD_DIR, 'uploads')
 const AVATAR_DIR = path.join(UPLOAD_DIR, 'avatars')
 const CHANNEL_AVATAR_DIR = path.join(AVATAR_DIR, 'channels')
 const VOICE_AVATAR_DIR = path.join(AVATAR_DIR, 'voice-rooms')
 
 if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR, { recursive: true })
-if (!fs.existsSync(path.join(UPLOAD_DIR, 'tmp'))) fs.mkdirSync(path.join(UPLOAD_DIR, 'tmp'), { recursive: true })
+const TEMP_DIR = path.join(UPLOAD_DIR, 'tmp')
+if (!fs.existsSync(TEMP_DIR)) fs.mkdirSync(TEMP_DIR, { recursive: true })
 if (!fs.existsSync(AVATAR_DIR)) fs.mkdirSync(AVATAR_DIR, { recursive: true })
 if (!fs.existsSync(CHANNEL_AVATAR_DIR)) fs.mkdirSync(CHANNEL_AVATAR_DIR, { recursive: true })
 if (!fs.existsSync(VOICE_AVATAR_DIR)) fs.mkdirSync(VOICE_AVATAR_DIR, { recursive: true })
 const UPLOADS_ROOT = path.resolve(UPLOAD_DIR)
 
-const db = new Database('messenger_v4.db')
+const db = new Database(DB_PATH)
 db.pragma('journal_mode = WAL')
 
 const identifierPattern = /^[A-Za-z_][A-Za-z0-9_]*$/
@@ -2338,7 +2363,77 @@ process.on('unhandledRejection', (reason) => {
   logError('Unhandled rejection', reason)
 })
 
-server.listen(PORT, () => log('Server listening on', PORT))
+let listenPromise = null
+
+export const stopMessengerServer = () => {
+  if (listenPromise) {
+    return listenPromise
+      .then(() => stopMessengerServer())
+      .catch((err) => {
+        logError('Server stop failed during startup', err)
+        throw err
+      })
+  }
+  try {
+    io.close()
+  } catch (err) {
+    logError('Socket close failed', err)
+  }
+  if (!server.listening) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        logError('Server close failed', err)
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+export const startMessengerServer = (options = {}) => {
+  if (server.listening) {
+    const address = server.address()
+    const resolvedPort = typeof address === 'object' && address?.port ? address.port : Number(PORT) || 0
+    const resolvedHost = typeof address === 'object' && address?.address ? address.address : '127.0.0.1'
+    return Promise.resolve({ port: resolvedPort, host: resolvedHost, httpServer: server, io, close: stopMessengerServer })
+  }
+  if (listenPromise) return listenPromise
+  const host = typeof options.host === 'string' && options.host.trim().length ? options.host.trim() : '127.0.0.1'
+  const requestedPort = Number(options.port ?? PORT)
+  const port = Number.isFinite(requestedPort) ? requestedPort : Number(PORT) || 0
+  listenPromise = new Promise((resolve, reject) => {
+    const handleError = (err) => {
+      server.off('error', handleError)
+      listenPromise = null
+      logError('Server failed to start', err)
+      reject(err)
+    }
+    server.once('error', handleError)
+    server.listen(port, host, () => {
+      server.off('error', handleError)
+      const address = server.address()
+      const resolvedPort = typeof address === 'object' && address?.port ? address.port : port
+      const resolvedHost = typeof address === 'object' && address?.address ? address.address : host
+      log('Server listening on', `${resolvedHost}:${resolvedPort}`)
+      const result = { port: resolvedPort, host: resolvedHost, httpServer: server, io, close: stopMessengerServer }
+      listenPromise = null
+      resolve(result)
+    })
+  })
+  return listenPromise
+}
+
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : null
+if (entryPath && entryPath === __filename) {
+  startMessengerServer().catch((err) => {
+    logError('Failed to start server', err)
+    process.exit(1)
+  })
+}
 
 
 


### PR DESCRIPTION
## Summary
- start the Node backend from the Electron main process, persist secrets, and surface the backend URL over IPC for the renderer
- expose backend URL helpers in the preload bridge and update the renderer store to auto-detect the local service with a desktop default
- package the server with the Electron build and refactor the backend to support configurable data paths plus start/stop helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe7ee721408320a1dd2c8f6b03a3cc